### PR TITLE
feat: commander statistics on player profile

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
@@ -1,3 +1,4 @@
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TournamentOrganizer.Api.DTOs;
 using TournamentOrganizer.Api.Services.Interfaces;
@@ -52,5 +53,14 @@ public class PlayersController : ControllerBase
     {
         var records = await _playerService.GetHeadToHeadAsync(id);
         return records == null ? NotFound() : Ok(records);
+    }
+
+    [HttpGet("{id}/commanderstats")]
+    [AllowAnonymous]
+    public async Task<ActionResult<PlayerCommanderStatsDto>> GetCommanderStats(int id)
+    {
+        var result = await _playerService.GetCommanderStatsAsync(id);
+        if (result == null) return NotFound();
+        return Ok(result);
     }
 }

--- a/src/TournamentOrganizer.Api/DTOs/PlayerDto.cs
+++ b/src/TournamentOrganizer.Api/DTOs/PlayerDto.cs
@@ -46,6 +46,18 @@ public record PlayerEventRegistrationDto(
     string? StoreName
 );
 
+public record CommanderStatDto(
+    string CommanderName,
+    int GamesPlayed,
+    int Wins,
+    double AvgFinish
+);
+
+public record PlayerCommanderStatsDto(
+    int PlayerId,
+    List<CommanderStatDto> Commanders
+);
+
 public record HeadToHeadEntryDto(
     int OpponentId,
     string OpponentName,

--- a/src/TournamentOrganizer.Api/Services/Interfaces/IPlayerService.cs
+++ b/src/TournamentOrganizer.Api/Services/Interfaces/IPlayerService.cs
@@ -10,4 +10,5 @@ public interface IPlayerService
     Task<List<PlayerDto>> GetAllAsync();
     Task<List<LeaderboardEntryDto>> GetLeaderboardAsync();
     Task<List<HeadToHeadEntryDto>?> GetHeadToHeadAsync(int playerId);
+    Task<PlayerCommanderStatsDto?> GetCommanderStatsAsync(int playerId);
 }

--- a/src/TournamentOrganizer.Api/Services/PlayerService.cs
+++ b/src/TournamentOrganizer.Api/Services/PlayerService.cs
@@ -143,6 +143,31 @@ public class PlayerService : IPlayerService
             .ToList();
     }
 
+    public async Task<PlayerCommanderStatsDto?> GetCommanderStatsAsync(int playerId)
+    {
+        var player = await _playerRepo.GetByIdAsync(playerId);
+        if (player == null) return null;
+
+        var registrations = await _playerRepo.GetPlayerEventRegistrationsAsync(playerId);
+        var results = await _gameRepo.GetPlayerResultsAsync(playerId);
+
+        var stats = registrations
+            .Where(r => r.Commanders != null)
+            .GroupBy(r => r.Commanders!)
+            .Select(g =>
+            {
+                var eventIds = g.Select(r => r.EventId).ToHashSet();
+                var relevant = results.Where(r => eventIds.Contains(r.Game.Pod.Round.EventId)).ToList();
+                var gamesPlayed = relevant.Count;
+                var wins = relevant.Count(r => r.FinishPosition == 1);
+                var avgFinish = gamesPlayed > 0 ? relevant.Average(r => r.FinishPosition) : 0.0;
+                return new CommanderStatDto(g.Key, gamesPlayed, wins, avgFinish);
+            })
+            .ToList();
+
+        return new PlayerCommanderStatsDto(playerId, stats);
+    }
+
     private static PlayerDto ToDto(Player p) => new(
         p.Id, p.Name, p.Email, p.Mu, p.Sigma, p.ConservativeScore, p.IsRanked, p.PlacementGamesLeft, p.IsActive);
 }

--- a/src/TournamentOrganizer.Tests/CommanderStatsTests.cs
+++ b/src/TournamentOrganizer.Tests/CommanderStatsTests.cs
@@ -1,0 +1,181 @@
+using TournamentOrganizer.Api.DTOs;
+using TournamentOrganizer.Api.Models;
+using TournamentOrganizer.Api.Repositories.Interfaces;
+using TournamentOrganizer.Api.Services;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// TDD tests for the Commander Statistics feature.
+/// </summary>
+public class CommanderStatsTests
+{
+    // ── Fakes ─────────────────────────────────────────────────────────────
+
+    private sealed class FakePlayerRepository : IPlayerRepository
+    {
+        private readonly List<Player> _players = [];
+        private readonly List<EventRegistration> _registrations = [];
+
+        public void Add(Player p) => _players.Add(p);
+        public void AddRegistration(EventRegistration r) => _registrations.Add(r);
+
+        public Task<Player?> GetByIdAsync(int id) =>
+            Task.FromResult(_players.FirstOrDefault(p => p.Id == id));
+        public Task<List<EventRegistration>> GetPlayerEventRegistrationsAsync(int playerId) =>
+            Task.FromResult(_registrations.Where(r => r.PlayerId == playerId).ToList());
+
+        // stubs
+        public Task<Player?> GetByEmailAsync(string email)                  => Task.FromResult<Player?>(null);
+        public Task<List<Player>> GetLeaderboardAsync()                      => Task.FromResult(new List<Player>());
+        public Task<List<Player>> GetAllAsync()                              => Task.FromResult(new List<Player>());
+        public Task<Player> CreateAsync(Player p)                            => Task.FromResult(p);
+        public Task UpdateAsync(Player p)                                    => Task.CompletedTask;
+        public Task UpdateRangeAsync(IEnumerable<Player> ps)                => Task.CompletedTask;
+        public Task<List<Player>> GetByIdsAsync(IEnumerable<int> ids)       => Task.FromResult(new List<Player>());
+    }
+
+    private sealed class FakeGameRepository : IGameRepository
+    {
+        private readonly List<GameResult> _results = [];
+
+        public void AddResult(GameResult r) => _results.Add(r);
+
+        public Task<List<GameResult>> GetPlayerResultsAsync(int playerId) =>
+            Task.FromResult(_results.Where(r => r.PlayerId == playerId).ToList());
+
+        // stubs
+        public Task<Game?> GetByIdAsync(int id)                                        => Task.FromResult<Game?>(null);
+        public Task<Game?> GetWithResultsAsync(int id)                                 => Task.FromResult<Game?>(null);
+        public Task<Game> CreateAsync(Game g)                                          => Task.FromResult(g);
+        public Task UpdateAsync(Game g)                                                => Task.CompletedTask;
+        public Task AddResultsAsync(IEnumerable<GameResult> r)                        => Task.CompletedTask;
+        public Task DeleteResultsAsync(int gameId)                                     => Task.CompletedTask;
+        public Task<List<GameResult>> GetPlayerGamesWithOpponentsAsync(int pid)        => Task.FromResult(new List<GameResult>());
+        public Task<List<int>> GetPreviousOpponentIdsAsync(int eid, int pid)           => Task.FromResult(new List<int>());
+    }
+
+    private static PlayerService BuildService(FakePlayerRepository playerRepo, FakeGameRepository gameRepo) =>
+        new(playerRepo, gameRepo);
+
+    private static Player MakePlayer(int id) =>
+        new() { Id = id, Name = $"Player{id}", Mu = 25, Sigma = 8.333 };
+
+    private static EventRegistration MakeRegistration(int playerId, int eventId, string? commanders) =>
+        new() { PlayerId = playerId, EventId = eventId, Commanders = commanders };
+
+    private static GameResult MakeResult(int playerId, int eventId, int finishPosition) =>
+        new()
+        {
+            PlayerId = playerId,
+            FinishPosition = finishPosition,
+            Game = new Game
+            {
+                Pod = new Pod
+                {
+                    Round = new Round { EventId = eventId }
+                }
+            }
+        };
+
+    // ── Tests ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetCommanderStatsAsync_MultipleCommanders_ReturnsGroupedStats()
+    {
+        var playerRepo = new FakePlayerRepository();
+        var gameRepo   = new FakeGameRepository();
+        playerRepo.Add(MakePlayer(1));
+        playerRepo.AddRegistration(MakeRegistration(1, 1, "Atraxa"));
+        playerRepo.AddRegistration(MakeRegistration(1, 2, "Omnath"));
+
+        gameRepo.AddResult(MakeResult(1, 1, 1)); // Atraxa event: win
+        gameRepo.AddResult(MakeResult(1, 1, 2)); // Atraxa event: 2nd
+        gameRepo.AddResult(MakeResult(1, 2, 3)); // Omnath event: 3rd
+
+        var svc = BuildService(playerRepo, gameRepo);
+        var result = await svc.GetCommanderStatsAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Equal(2, result!.Commanders.Count);
+
+        var atraxa = result.Commanders.Single(c => c.CommanderName == "Atraxa");
+        Assert.Equal(2, atraxa.GamesPlayed);
+        Assert.Equal(1, atraxa.Wins);
+
+        var omnath = result.Commanders.Single(c => c.CommanderName == "Omnath");
+        Assert.Equal(1, omnath.GamesPlayed);
+        Assert.Equal(0, omnath.Wins);
+    }
+
+    [Fact]
+    public async Task GetCommanderStatsAsync_SingleCommander_ComputesWinRateCorrectly()
+    {
+        var playerRepo = new FakePlayerRepository();
+        var gameRepo   = new FakeGameRepository();
+        playerRepo.Add(MakePlayer(1));
+        playerRepo.AddRegistration(MakeRegistration(1, 1, "Atraxa"));
+
+        gameRepo.AddResult(MakeResult(1, 1, 1)); // win
+        gameRepo.AddResult(MakeResult(1, 1, 1)); // win
+        gameRepo.AddResult(MakeResult(1, 1, 3)); // 3rd
+
+        var svc = BuildService(playerRepo, gameRepo);
+        var result = await svc.GetCommanderStatsAsync(1);
+
+        Assert.NotNull(result);
+        var stat = Assert.Single(result!.Commanders);
+        Assert.Equal(3, stat.GamesPlayed);
+        Assert.Equal(2, stat.Wins);
+    }
+
+    [Fact]
+    public async Task GetCommanderStatsAsync_NoCommandersDeclared_ReturnsEmptyList()
+    {
+        var playerRepo = new FakePlayerRepository();
+        var gameRepo   = new FakeGameRepository();
+        playerRepo.Add(MakePlayer(1));
+        playerRepo.AddRegistration(MakeRegistration(1, 1, null)); // no commander declared
+
+        gameRepo.AddResult(MakeResult(1, 1, 2));
+
+        var svc = BuildService(playerRepo, gameRepo);
+        var result = await svc.GetCommanderStatsAsync(1);
+
+        Assert.NotNull(result);
+        Assert.Empty(result!.Commanders);
+    }
+
+    [Fact]
+    public async Task GetCommanderStatsAsync_PlayerNotFound_ReturnsNull()
+    {
+        var playerRepo = new FakePlayerRepository();
+        var gameRepo   = new FakeGameRepository();
+        // no players added
+
+        var svc = BuildService(playerRepo, gameRepo);
+        var result = await svc.GetCommanderStatsAsync(99);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task GetCommanderStatsAsync_AvgFinish_ComputedCorrectly()
+    {
+        var playerRepo = new FakePlayerRepository();
+        var gameRepo   = new FakeGameRepository();
+        playerRepo.Add(MakePlayer(1));
+        playerRepo.AddRegistration(MakeRegistration(1, 1, "Atraxa"));
+
+        gameRepo.AddResult(MakeResult(1, 1, 1)); // finish 1
+        gameRepo.AddResult(MakeResult(1, 1, 3)); // finish 3
+        // avg = 2.0
+
+        var svc = BuildService(playerRepo, gameRepo);
+        var result = await svc.GetCommanderStatsAsync(1);
+
+        Assert.NotNull(result);
+        var stat = Assert.Single(result!.Commanders);
+        Assert.Equal(2.0, stat.AvgFinish, precision: 5);
+    }
+}

--- a/tournament-client/e2e/helpers/api-mock.ts
+++ b/tournament-client/e2e/helpers/api-mock.ts
@@ -1,5 +1,5 @@
 import { Page } from '@playwright/test';
-import { CheckInResponseDto, EventDto, EventPlayerDto, LeaderboardEntry, PairingsDto, PlayerDto, PlayerProfile, StoreDto, StoreDetailDto, ThemeDto } from '../../src/app/core/models/api.models';
+import { CheckInResponseDto, CommanderStatDto, EventDto, EventPlayerDto, LeaderboardEntry, PairingsDto, PlayerCommanderStatsDto, PlayerDto, PlayerProfile, StoreDto, StoreDetailDto, ThemeDto } from '../../src/app/core/models/api.models';
 
 /** Intercept GET /api/events and return the given list. */
 export async function mockGetEvents(page: Page, events: EventDto[]): Promise<void> {
@@ -332,6 +332,22 @@ export async function mockCheckInByToken(
 
 export function makeCheckInResponseDto(overrides: Partial<CheckInResponseDto> = {}): CheckInResponseDto {
   return { eventId: 1, eventName: 'Friday Night Magic', ...overrides };
+}
+
+export function makeCommanderStatDto(overrides: Partial<CommanderStatDto> = {}): CommanderStatDto {
+  return { commanderName: 'Atraxa', gamesPlayed: 5, wins: 3, avgFinish: 1.8, ...overrides };
+}
+
+export async function mockGetCommanderStats(
+  page: Page, playerId: number, response: PlayerCommanderStatsDto
+): Promise<void> {
+  await page.route(`**/api/players/${playerId}/commanderstats`, route => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({ json: response });
+    } else {
+      route.continue();
+    }
+  });
 }
 
 export function makePairingsDto(overrides: Partial<PairingsDto> = {}): PairingsDto {

--- a/tournament-client/e2e/players/player-profile.spec.ts
+++ b/tournament-client/e2e/players/player-profile.spec.ts
@@ -3,8 +3,10 @@ import { loginAs } from '../helpers/auth';
 import {
   stubUnmatchedApi,
   mockGetPlayerProfile,
+  mockGetCommanderStats,
   makePlayerProfile,
   makePlayerDto,
+  makeCommanderStatDto,
 } from '../helpers/api-mock';
 
 // ─── Player Profile (/players/:id) ────────────────────────────────────────────
@@ -67,5 +69,89 @@ test.describe('Player Profile — offline (API 500)', () => {
   test('Trading tab is NOT visible', async ({ page }) => {
     const tabs = page.getByRole('tab');
     await expect(tabs.filter({ hasText: 'Trading' })).not.toBeVisible();
+  });
+});
+
+// ── Commander Stats ───────────────────────────────────────────────────────────
+
+const PLAYER_ID = 1;
+
+test.describe('Player Profile — Commander Stats: display', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'Player');
+    await stubUnmatchedApi(page);
+    await mockGetCommanderStats(page, PLAYER_ID, {
+      playerId: PLAYER_ID,
+      commanders: [makeCommanderStatDto({ commanderName: 'Atraxa', gamesPlayed: 5, wins: 3, avgFinish: 1.8 })],
+    });
+    await mockGetPlayerProfile(page, makePlayerProfile({ id: PLAYER_ID }));
+    await page.goto(`/players/${PLAYER_ID}`);
+  });
+
+  test('shows My Commanders heading', async ({ page }) => {
+    await expect(page.getByText('My Commanders')).toBeVisible();
+  });
+
+  test('shows the commander name row', async ({ page }) => {
+    await expect(page.getByText('Atraxa')).toBeVisible();
+  });
+
+  test('shows correct win % (60.0%)', async ({ page }) => {
+    await expect(page.getByText('60.0%')).toBeVisible();
+  });
+});
+
+test.describe('Player Profile — Commander Stats: multiple commanders', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'Player');
+    await stubUnmatchedApi(page);
+    await mockGetCommanderStats(page, PLAYER_ID, {
+      playerId: PLAYER_ID,
+      commanders: [
+        makeCommanderStatDto({ commanderName: 'Atraxa', gamesPlayed: 5, wins: 3, avgFinish: 1.8 }),
+        makeCommanderStatDto({ commanderName: 'Omnath', gamesPlayed: 3, wins: 1, avgFinish: 2.3 }),
+        makeCommanderStatDto({ commanderName: 'Zur',    gamesPlayed: 2, wins: 2, avgFinish: 1.0 }),
+      ],
+    });
+    await mockGetPlayerProfile(page, makePlayerProfile({ id: PLAYER_ID }));
+    await page.goto(`/players/${PLAYER_ID}`);
+  });
+
+  test('shows all 3 commander rows', async ({ page }) => {
+    await expect(page.getByText('Atraxa')).toBeVisible();
+    await expect(page.getByText('Omnath')).toBeVisible();
+    await expect(page.getByText('Zur')).toBeVisible();
+  });
+});
+
+test.describe('Player Profile — Commander Stats: empty', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'Player');
+    await stubUnmatchedApi(page);
+    await mockGetCommanderStats(page, PLAYER_ID, { playerId: PLAYER_ID, commanders: [] });
+    await mockGetPlayerProfile(page, makePlayerProfile({ id: PLAYER_ID }));
+    await page.goto(`/players/${PLAYER_ID}`);
+  });
+
+  test('My Commanders section is NOT visible when no commanders', async ({ page }) => {
+    await expect(page.getByText('My Commanders')).not.toBeVisible();
+  });
+});
+
+test.describe('Player Profile — Commander Stats: zero games guard', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'Player');
+    await stubUnmatchedApi(page);
+    await mockGetCommanderStats(page, PLAYER_ID, {
+      playerId: PLAYER_ID,
+      commanders: [makeCommanderStatDto({ commanderName: 'Atraxa', gamesPlayed: 0, wins: 0, avgFinish: 0 })],
+    });
+    await mockGetPlayerProfile(page, makePlayerProfile({ id: PLAYER_ID }));
+    await page.goto(`/players/${PLAYER_ID}`);
+  });
+
+  test('shows 0.0% not NaN when gamesPlayed is 0', async ({ page }) => {
+    await expect(page.getByText('0.0%')).toBeVisible();
+    await expect(page.getByText('NaN')).not.toBeVisible();
   });
 });

--- a/tournament-client/src/app/core/models/api.models.ts
+++ b/tournament-client/src/app/core/models/api.models.ts
@@ -79,6 +79,18 @@ export interface PlayerEventRegistration {
   storeName: string | null;
 }
 
+export interface CommanderStatDto {
+  commanderName: string;
+  gamesPlayed: number;
+  wins: number;
+  avgFinish: number;
+}
+
+export interface PlayerCommanderStatsDto {
+  playerId: number;
+  commanders: CommanderStatDto[];
+}
+
 // Event DTOs
 export type PointSystem = 'ScoreBased' | 'WinBased' | 'VictoryPoints' | 'PointWager' | 'SocialVoting' | 'FiveOneZero' | 'SeatBased';
 

--- a/tournament-client/src/app/core/services/api.service.ts
+++ b/tournament-client/src/app/core/services/api.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import {
-  CreatePlayerDto, UpdatePlayerDto, PlayerDto, PlayerProfile, LeaderboardEntry,
+  CreatePlayerDto, UpdatePlayerDto, PlayerDto, PlayerProfile, PlayerCommanderStatsDto, LeaderboardEntry,
   CreateEventDto, EventDto, RegisterPlayerDto, EventPlayerDto, CheckInResponseDto,
   GameResultSubmit, RoundDto, StandingsEntry, PairingsDto,
   WishlistEntryDto, TradeEntryDto, CreateCardEntryDto, BulkUploadResultDto,
@@ -34,6 +34,10 @@ export class ApiService {
 
   getPlayerProfile(id: number): Observable<PlayerProfile> {
     return this.http.get<PlayerProfile>(`${this.base}/players/${id}/profile`);
+  }
+
+  getCommanderStats(playerId: number): Observable<PlayerCommanderStatsDto> {
+    return this.http.get<PlayerCommanderStatsDto>(`${this.base}/players/${playerId}/commanderstats`);
   }
 
   // Leaderboard

--- a/tournament-client/src/app/features/player-profile/player-profile.component.spec.ts
+++ b/tournament-client/src/app/features/player-profile/player-profile.component.spec.ts
@@ -10,7 +10,7 @@ import { PlayerService } from '../../core/services/player.service';
 import { ApiService } from '../../core/services/api.service';
 import { AuthService } from '../../core/services/auth.service';
 import { LocalStorageContext } from '../../core/services/local-storage-context.service';
-import { PlayerProfile, PlayerDto } from '../../core/models/api.models';
+import { PlayerProfile, PlayerDto, CommanderStatDto } from '../../core/models/api.models';
 
 describe('PlayerProfileComponent (smoke)', () => {
   const profileStub: PlayerProfile = {
@@ -89,11 +89,12 @@ describe('PlayerProfileComponent — tab visibility by API state', () => {
 
   let mockPlayerService: { getProfile: jest.Mock; updatePlayer: jest.Mock };
   let mockApi: {
-    getWishlist:       jest.Mock;
-    getWishlistSupply: jest.Mock;
-    getTradeList:      jest.Mock;
+    getWishlist:        jest.Mock;
+    getWishlistSupply:  jest.Mock;
+    getTradeList:       jest.Mock;
     getSuggestedTrades: jest.Mock;
-    getTradeDemand:    jest.Mock;
+    getTradeDemand:     jest.Mock;
+    getCommanderStats:  jest.Mock;
   };
   let mockCtx: { players: { getById: jest.Mock; getAll: jest.Mock } };
   let mockAuth: { currentUser: null };
@@ -113,6 +114,7 @@ describe('PlayerProfileComponent — tab visibility by API state', () => {
       getTradeList:       jest.fn().mockReturnValue(of([])),
       getSuggestedTrades: jest.fn().mockReturnValue(of([])),
       getTradeDemand:     jest.fn().mockReturnValue(of([])),
+      getCommanderStats:  jest.fn().mockReturnValue(of({ playerId: PLAYER_ID, commanders: [] })),
     };
     mockCtx     = { players: { getById: jest.fn().mockReturnValue(cachedPlayer), getAll: jest.fn().mockReturnValue([]) } };
     mockAuth    = { currentUser: null };
@@ -200,5 +202,86 @@ describe('PlayerProfileComponent — tab visibility by API state', () => {
     const fixture = TestBed.createComponent(PlayerProfileComponent);
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).toContain('Alice');
+  });
+});
+
+// ── Commander Stats ───────────────────────────────────────────────────────────
+
+describe('PlayerProfileComponent — Commander Stats', () => {
+  const PLAYER_ID = 1;
+  const profileStub: PlayerProfile = {
+    id: PLAYER_ID, name: 'Alice', email: 'alice@test.com',
+    mu: 25, sigma: 8.333, conservativeScore: 0,
+    isRanked: true, placementGamesLeft: 0, isActive: true,
+    gameHistory: [], eventRegistrations: [],
+  };
+
+  function makeCommanderStat(overrides: Partial<CommanderStatDto> = {}): CommanderStatDto {
+    return { commanderName: 'Atraxa', gamesPlayed: 5, wins: 3, avgFinish: 1.8, ...overrides };
+  }
+
+  async function setup(commanders: CommanderStatDto[]) {
+    const mockPlayerService = {
+      getProfile:   jest.fn().mockReturnValue(of(profileStub)),
+      updatePlayer: jest.fn().mockReturnValue(of(profileStub)),
+    };
+    const mockApi = {
+      getWishlist:        jest.fn().mockReturnValue(of([])),
+      getWishlistSupply:  jest.fn().mockReturnValue(of([])),
+      getTradeList:       jest.fn().mockReturnValue(of([])),
+      getSuggestedTrades: jest.fn().mockReturnValue(of([])),
+      getTradeDemand:     jest.fn().mockReturnValue(of([])),
+      getCommanderStats:  jest.fn().mockReturnValue(of({ playerId: PLAYER_ID, commanders })),
+    };
+    const mockCtx  = { players: { getById: jest.fn().mockReturnValue(null), getAll: jest.fn().mockReturnValue([]) } };
+    const mockAuth = { currentUser: null };
+
+    await TestBed.configureTestingModule({
+      imports: [PlayerProfileComponent],
+      providers: [
+        provideRouter([]),
+        provideAnimationsAsync(),
+        { provide: ActivatedRoute,      useValue: { snapshot: { paramMap: { get: () => String(PLAYER_ID) } } } },
+        { provide: PlayerService,       useValue: mockPlayerService },
+        { provide: ApiService,          useValue: mockApi },
+        { provide: LocalStorageContext, useValue: mockCtx },
+        { provide: AuthService,         useValue: mockAuth },
+        { provide: MatDialog,           useValue: { open: jest.fn() } },
+        { provide: MatSnackBar,         useValue: { open: jest.fn() } },
+      ],
+    }).compileComponents();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('shows My Commanders heading and row when commander data is present', async () => {
+    await setup([makeCommanderStat()]);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.textContent).toContain('My Commanders');
+    expect(el.textContent).toContain('Atraxa');
+  });
+
+  it('shows correct win % for a commander', async () => {
+    // 3 wins / 5 games = 60.0%
+    await setup([makeCommanderStat({ gamesPlayed: 5, wins: 3 })]);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('60.0%');
+  });
+
+  it('hides My Commanders section when commanders list is empty', async () => {
+    await setup([]);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).not.toContain('My Commanders');
+  });
+
+  it('shows 0.0% win rate when gamesPlayed is 0 (guards against NaN)', async () => {
+    await setup([makeCommanderStat({ gamesPlayed: 0, wins: 0 })]);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('0.0%');
   });
 });

--- a/tournament-client/src/app/features/player-profile/player-profile.component.ts
+++ b/tournament-client/src/app/features/player-profile/player-profile.component.ts
@@ -18,7 +18,7 @@ import { ApiService } from '../../core/services/api.service';
 import { AuthService } from '../../core/services/auth.service';
 import { PlayerService } from '../../core/services/player.service';
 import { LocalStorageContext } from '../../core/services/local-storage-context.service';
-import { PlayerProfile, WishlistEntryDto, TradeEntryDto, BulkUploadResultDto, SuggestedTradeDto, TradeCardDemandDto } from '../../core/models/api.models';
+import { PlayerProfile, WishlistEntryDto, TradeEntryDto, BulkUploadResultDto, SuggestedTradeDto, TradeCardDemandDto, CommanderStatDto } from '../../core/models/api.models';
 import { RatingBadgeComponent } from '../../shared/components/rating-badge.component';
 import { PlacementBadgeComponent } from '../../shared/components/placement-badge.component';
 
@@ -70,6 +70,42 @@ import { PlacementBadgeComponent } from '../../shared/components/placement-badge
           </div>
         </div>
       </div>
+
+      @if (commanderStats.length) {
+        <div class="commander-stats-section">
+          <h3>My Commanders</h3>
+          <mat-card>
+            <mat-card-content>
+              <table mat-table [dataSource]="commanderStats" class="full-width">
+                <ng-container matColumnDef="commanderName">
+                  <th mat-header-cell *matHeaderCellDef>Commander(s)</th>
+                  <td mat-cell *matCellDef="let row">{{ row.commanderName }}</td>
+                </ng-container>
+                <ng-container matColumnDef="gamesPlayed">
+                  <th mat-header-cell *matHeaderCellDef>Games</th>
+                  <td mat-cell *matCellDef="let row">{{ row.gamesPlayed }}</td>
+                </ng-container>
+                <ng-container matColumnDef="wins">
+                  <th mat-header-cell *matHeaderCellDef>Wins</th>
+                  <td mat-cell *matCellDef="let row">{{ row.wins }}</td>
+                </ng-container>
+                <ng-container matColumnDef="winPct">
+                  <th mat-header-cell *matHeaderCellDef>Win %</th>
+                  <td mat-cell *matCellDef="let row">
+                    {{ row.gamesPlayed > 0 ? (row.wins / row.gamesPlayed * 100).toFixed(1) : '0.0' }}%
+                  </td>
+                </ng-container>
+                <ng-container matColumnDef="avgFinish">
+                  <th mat-header-cell *matHeaderCellDef>Avg Finish</th>
+                  <td mat-cell *matCellDef="let row">{{ row.avgFinish | number:'1.1-2' }}</td>
+                </ng-container>
+                <tr mat-header-row *matHeaderRowDef="commanderColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: commanderColumns;"></tr>
+              </table>
+            </mat-card-content>
+          </mat-card>
+        </div>
+      }
 
       <mat-tab-group>
 
@@ -365,6 +401,7 @@ import { PlacementBadgeComponent } from '../../shared/components/placement-badge
 })
 export class PlayerProfileComponent implements OnInit {
   profile: PlayerProfile | null = null;
+  commanderStats: CommanderStatDto[] = [];
   wishlist: WishlistEntryDto[] = [];
   wishlistSupply = new Map<string, string[]>();
   tradeList: TradeEntryDto[] = [];
@@ -372,6 +409,7 @@ export class PlayerProfileComponent implements OnInit {
   tradeDemand = new Map<string, TradeCardDemandDto>();
 
   eventColumns = ['eventName', 'eventDate', 'decklist', 'commander', 'store'];
+  commanderColumns = ['commanderName', 'gamesPlayed', 'wins', 'winPct', 'avgFinish'];
   historyPageSize = 10;
   historyPageIndex = 0;
 
@@ -437,6 +475,7 @@ export class PlayerProfileComponent implements OnInit {
         this.loadTradeList(id);
         this.loadSuggestedTrades(id);
         this.loadTradeDemand(id);
+        this.loadCommanderStats(id);
       },
       error: () => {
         this.apiOnline = false;
@@ -449,6 +488,13 @@ export class PlayerProfileComponent implements OnInit {
           this.snackBar.open('Player profile unavailable offline', 'OK', { duration: 3000 });
         }
       }
+    });
+  }
+
+  private loadCommanderStats(playerId: number) {
+    this.apiService.getCommanderStats(playerId).subscribe({
+      next: stats => { this.commanderStats = stats.commanders; this.cdr.detectChanges(); },
+      error: () => {}
     });
   }
 


### PR DESCRIPTION
## Summary
- New `GET /api/players/{id}/commanderstats` endpoint groups `EventRegistration.Commanders` with `GameResult` finish positions to compute per-commander stats (games played, wins, avg finish, win %)
- Angular player profile now shows a **My Commanders** table above the tabs when commander data is present
- No migration needed — reuses the existing `EventRegistration.Commanders` field

## Test plan
- [x] 5 backend xUnit tests (`CommanderStatsTests`) — all pass
- [x] 4 Jest unit tests in `player-profile.component.spec.ts` — all pass
- [x] 12 Playwright E2E tests in `e2e/players/player-profile.spec.ts` — all pass
- [x] `/check-zone` on `player-profile.component.ts` — clean
- [x] `/build` — 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)