### PR TITLE
fix: redirect when navigating to unsynced offline event

### DIFF
--- a/tournament-client/src/app/features/events/event-detail.component.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.ts
@@ -483,6 +483,11 @@ export class EventDetailComponent implements OnInit {
 
   ngOnInit() {
     this.eventId = Number(this.route.snapshot.paramMap.get('id'));
+    if (this.eventId < 0) {
+      this.snackBar.open('This event was created offline and has not yet synced to the server.', 'OK', { duration: 5000 });
+      this.router.navigate(['/events']);
+      return;
+    }
     this.initSubscriptions();
     this.loadData();
   }


### PR DESCRIPTION
## Summary
- Offline-created events get negative IDs (e.g. `-1`) in local storage
- Navigating to `/events/-1` caused all backend write operations (declare commander, check-in, etc.) to silently return 404 with no user-facing explanation
- `ngOnInit` now detects `eventId < 0`, shows a clear snackbar message, and redirects back to `/events`

## Root cause
`loadAllEvents()` in `EventService` seeds the subject from local cache, which includes offline events with negative IDs. The event list rendered cards with `[routerLink]="['/events', evt.id]"`, so clicking an unsynced event navigated to `/events/-1`.

## Test plan
- [x] Navigate to an event with a positive ID — works as before
- [x] Manually navigate to `/events/-1` — snackbar appears and page redirects to `/events`

🤖 Generated with [Claude Code](https://claude.com/claude-code)