### PR TITLE
fix: commander stats group by CommanderPlayed (not EventRegistration)

### DIFF
--- a/src/TournamentOrganizer.Api/Services/PlayerService.cs
+++ b/src/TournamentOrganizer.Api/Services/PlayerService.cs
@@ -148,19 +148,16 @@ public class PlayerService : IPlayerService
         var player = await _playerRepo.GetByIdAsync(playerId);
         if (player == null) return null;
 
-        var registrations = await _playerRepo.GetPlayerEventRegistrationsAsync(playerId);
         var results = await _gameRepo.GetPlayerResultsAsync(playerId);
 
-        var stats = registrations
-            .Where(r => r.Commanders != null)
-            .GroupBy(r => r.Commanders!)
+        var stats = results
+            .Where(r => r.CommanderPlayed != null)
+            .GroupBy(r => r.CommanderPlayed!)
             .Select(g =>
             {
-                var eventIds = g.Select(r => r.EventId).ToHashSet();
-                var relevant = results.Where(r => eventIds.Contains(r.Game.Pod.Round.EventId)).ToList();
-                var gamesPlayed = relevant.Count;
-                var wins = relevant.Count(r => r.FinishPosition == 1);
-                var avgFinish = gamesPlayed > 0 ? relevant.Average(r => r.FinishPosition) : 0.0;
+                var gamesPlayed = g.Count();
+                var wins = g.Count(r => r.FinishPosition == 1);
+                var avgFinish = gamesPlayed > 0 ? g.Average(r => r.FinishPosition) : 0.0;
                 return new CommanderStatDto(g.Key, gamesPlayed, wins, avgFinish);
             })
             .ToList();

--- a/src/TournamentOrganizer.Tests/CommanderStatsTests.cs
+++ b/src/TournamentOrganizer.Tests/CommanderStatsTests.cs
@@ -61,21 +61,13 @@ public class CommanderStatsTests
     private static Player MakePlayer(int id) =>
         new() { Id = id, Name = $"Player{id}", Mu = 25, Sigma = 8.333 };
 
-    private static EventRegistration MakeRegistration(int playerId, int eventId, string? commanders) =>
-        new() { PlayerId = playerId, EventId = eventId, Commanders = commanders };
-
-    private static GameResult MakeResult(int playerId, int eventId, int finishPosition) =>
+    private static GameResult MakeResult(int playerId, int finishPosition, string? commanderPlayed = null) =>
         new()
         {
             PlayerId = playerId,
             FinishPosition = finishPosition,
-            Game = new Game
-            {
-                Pod = new Pod
-                {
-                    Round = new Round { EventId = eventId }
-                }
-            }
+            CommanderPlayed = commanderPlayed,
+            Game = new Game { Pod = new Pod { Round = new Round { EventId = 1 } } }
         };
 
     // ── Tests ─────────────────────────────────────────────────────────────
@@ -86,12 +78,10 @@ public class CommanderStatsTests
         var playerRepo = new FakePlayerRepository();
         var gameRepo   = new FakeGameRepository();
         playerRepo.Add(MakePlayer(1));
-        playerRepo.AddRegistration(MakeRegistration(1, 1, "Atraxa"));
-        playerRepo.AddRegistration(MakeRegistration(1, 2, "Omnath"));
 
-        gameRepo.AddResult(MakeResult(1, 1, 1)); // Atraxa event: win
-        gameRepo.AddResult(MakeResult(1, 1, 2)); // Atraxa event: 2nd
-        gameRepo.AddResult(MakeResult(1, 2, 3)); // Omnath event: 3rd
+        gameRepo.AddResult(MakeResult(1, 1, "Atraxa")); // win
+        gameRepo.AddResult(MakeResult(1, 2, "Atraxa")); // 2nd
+        gameRepo.AddResult(MakeResult(1, 3, "Omnath")); // 3rd
 
         var svc = BuildService(playerRepo, gameRepo);
         var result = await svc.GetCommanderStatsAsync(1);
@@ -114,11 +104,10 @@ public class CommanderStatsTests
         var playerRepo = new FakePlayerRepository();
         var gameRepo   = new FakeGameRepository();
         playerRepo.Add(MakePlayer(1));
-        playerRepo.AddRegistration(MakeRegistration(1, 1, "Atraxa"));
 
-        gameRepo.AddResult(MakeResult(1, 1, 1)); // win
-        gameRepo.AddResult(MakeResult(1, 1, 1)); // win
-        gameRepo.AddResult(MakeResult(1, 1, 3)); // 3rd
+        gameRepo.AddResult(MakeResult(1, 1, "Atraxa")); // win
+        gameRepo.AddResult(MakeResult(1, 1, "Atraxa")); // win
+        gameRepo.AddResult(MakeResult(1, 3, "Atraxa")); // 3rd
 
         var svc = BuildService(playerRepo, gameRepo);
         var result = await svc.GetCommanderStatsAsync(1);
@@ -130,14 +119,13 @@ public class CommanderStatsTests
     }
 
     [Fact]
-    public async Task GetCommanderStatsAsync_NoCommandersDeclared_ReturnsEmptyList()
+    public async Task GetCommanderStatsAsync_NoCommanderPlayed_ReturnsEmptyList()
     {
         var playerRepo = new FakePlayerRepository();
         var gameRepo   = new FakeGameRepository();
         playerRepo.Add(MakePlayer(1));
-        playerRepo.AddRegistration(MakeRegistration(1, 1, null)); // no commander declared
 
-        gameRepo.AddResult(MakeResult(1, 1, 2));
+        gameRepo.AddResult(MakeResult(1, 2, null)); // no commander recorded
 
         var svc = BuildService(playerRepo, gameRepo);
         var result = await svc.GetCommanderStatsAsync(1);
@@ -165,10 +153,9 @@ public class CommanderStatsTests
         var playerRepo = new FakePlayerRepository();
         var gameRepo   = new FakeGameRepository();
         playerRepo.Add(MakePlayer(1));
-        playerRepo.AddRegistration(MakeRegistration(1, 1, "Atraxa"));
 
-        gameRepo.AddResult(MakeResult(1, 1, 1)); // finish 1
-        gameRepo.AddResult(MakeResult(1, 1, 3)); // finish 3
+        gameRepo.AddResult(MakeResult(1, 1, "Atraxa")); // finish 1
+        gameRepo.AddResult(MakeResult(1, 3, "Atraxa")); // finish 3
         // avg = 2.0
 
         var svc = BuildService(playerRepo, gameRepo);


### PR DESCRIPTION
## Summary
- `GetCommanderStatsAsync` was grouping by `EventRegistration.Commanders`, which is only populated via the inline declare-commander edit flow
- Commanders entered during game result submission are stored in `GameResult.CommanderPlayed` — a completely separate field that was being ignored
- Fix: group directly by `GameResult.CommanderPlayed` from the results query (simpler, no registration lookup needed)
- Updated `CommanderStatsTests` to set `CommanderPlayed` on `GameResult` instead of using registrations

## Test plan
- [ ] Backend xUnit: `CommanderStatsTests` (5 tests) — run after stopping API server to release file lock
- [ ] Frontend Jest: `player-profile.component.spec.ts` — 15/15 passed ✅
- [ ] E2E Playwright: `e2e/players/player-profile.spec.ts` — 12/12 passed ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)