### PR TITLE
feat: add public landing page at /

### DIFF
--- a/tournament-client/e2e/landing/landing.spec.ts
+++ b/tournament-client/e2e/landing/landing.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from '../helpers/auth';
+import {
+  stubUnmatchedApi,
+  mockGetEvents,
+  mockGetLeaderboard,
+  makeEventDto,
+  makeLeaderboardEntry,
+} from '../helpers/api-mock';
+
+test.describe('Landing — hero', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, []);
+    await mockGetLeaderboard(page, []);
+    await loginAs(page, 'Player');
+    await page.goto('/');
+  });
+
+  test('heading "Commander Tournament Organizer" is visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Commander Tournament Organizer', level: 1 })).toBeVisible();
+  });
+
+  test('"Browse Events" button is visible', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'Browse Events' })).toBeVisible();
+  });
+});
+
+test.describe('Landing — featured events (empty)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, []);
+    await mockGetLeaderboard(page, []);
+    await loginAs(page, 'Player');
+    await page.goto('/');
+  });
+
+  test('shows "No upcoming events"', async ({ page }) => {
+    await expect(page.locator('.empty-state')).toContainText('No upcoming events');
+  });
+});
+
+test.describe('Landing — featured events (populated)', () => {
+  const registrationEvent = makeEventDto({ id: 10, name: 'Friday Night Commander', status: 'Registration' });
+  const inProgressEvent = makeEventDto({ id: 11, name: 'In Progress Event', status: 'InProgress' });
+
+  test.beforeEach(async ({ page }) => {
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, [registrationEvent, inProgressEvent]);
+    await mockGetLeaderboard(page, []);
+    await loginAs(page, 'Player');
+    await page.goto('/');
+  });
+
+  test('Registration event card renders', async ({ page }) => {
+    await expect(page.locator('mat-card.event-card')).toHaveCount(1);
+    await expect(page.locator('mat-card.event-card .event-name')).toContainText('Friday Night Commander');
+  });
+
+  test('InProgress event is NOT shown', async ({ page }) => {
+    const cards = page.locator('mat-card.event-card');
+    await expect(cards).toHaveCount(1);
+    await expect(page.locator('mat-card.event-card')).not.toContainText('In Progress Event');
+  });
+
+  test('card click navigates to /events/:id', async ({ page }) => {
+    await page.locator('mat-card.event-card').click();
+    await expect(page).toHaveURL(/\/events\/10/);
+  });
+});
+
+test.describe('Landing — leaderboard preview', () => {
+  const entries = Array.from({ length: 7 }, (_, i) =>
+    makeLeaderboardEntry({ rank: i + 1, playerId: i + 1, name: `Player ${i + 1}` })
+  );
+
+  test.beforeEach(async ({ page }) => {
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, []);
+    await mockGetLeaderboard(page, entries);
+    await loginAs(page, 'Player');
+    await page.goto('/');
+  });
+
+  test('"Top Players" heading is visible', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Top Players', level: 2 })).toBeVisible();
+  });
+
+  test('shows exactly 5 leaderboard rows', async ({ page }) => {
+    await expect(page.locator('tr.leaderboard-row')).toHaveCount(5);
+  });
+
+  test('"View Full Leaderboard" link is present', async ({ page }) => {
+    await expect(page.getByRole('link', { name: 'View Full Leaderboard' })).toBeVisible();
+  });
+});
+
+test.describe('Landing — role UI', () => {
+  test('"Host a Tournament" is visible for StoreEmployee', async ({ page }) => {
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, []);
+    await mockGetLeaderboard(page, []);
+    await loginAs(page, 'StoreEmployee');
+    await page.goto('/');
+    await expect(page.getByRole('link', { name: 'Host a Tournament' })).toBeVisible();
+  });
+
+  test('"Host a Tournament" is NOT visible for Player', async ({ page }) => {
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, []);
+    await mockGetLeaderboard(page, []);
+    await loginAs(page, 'Player');
+    await page.goto('/');
+    await expect(page.getByRole('link', { name: 'Host a Tournament' })).not.toBeVisible();
+  });
+});

--- a/tournament-client/src/app/app.html
+++ b/tournament-client/src/app/app.html
@@ -5,6 +5,10 @@
       <span>Commander Tournament</span>
     </div> -->
     <mat-nav-list>
+      <a mat-list-item routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{exact:true}">
+        <mat-icon matListItemIcon>home</mat-icon>
+        <span matListItemTitle>Home</span>
+      </a>
       <a mat-list-item routerLink="/leaderboard" routerLinkActive="active">
         <mat-icon matListItemIcon>leaderboard</mat-icon>
         <span matListItemTitle>Leaderboard</span>

--- a/tournament-client/src/app/app.routes.ts
+++ b/tournament-client/src/app/app.routes.ts
@@ -2,7 +2,7 @@ import { Routes } from '@angular/router';
 import { authGuard } from './core/guards/auth.guard';
 
 export const routes: Routes = [
-  { path: '', redirectTo: '/leaderboard', pathMatch: 'full' },
+  { path: '', loadComponent: () => import('./features/landing/landing.component').then(m => m.LandingComponent) },
   {
     path: 'login',
     loadComponent: () => import('./features/auth/login.component').then(m => m.LoginComponent)

--- a/tournament-client/src/app/features/landing/landing.component.spec.ts
+++ b/tournament-client/src/app/features/landing/landing.component.spec.ts
@@ -1,0 +1,145 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { RouterLink } from '@angular/router';
+import { of } from 'rxjs';
+import { provideRouter } from '@angular/router';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { LandingComponent } from './landing.component';
+import { ApiService } from '../../core/services/api.service';
+import { AuthService } from '../../core/services/auth.service';
+import { makeEventDto, makeLeaderboardEntry } from '../../../../e2e/helpers/api-mock';
+
+const mockApi = {
+  getAllEvents: jest.fn().mockReturnValue(of([])),
+  getLeaderboard: jest.fn().mockReturnValue(of([])),
+};
+
+function makeAuthService(isStoreEmployee: boolean) {
+  return { isStoreEmployee };
+}
+
+describe('LandingComponent', () => {
+  let fixture: ComponentFixture<LandingComponent>;
+  let component: LandingComponent;
+
+  function setup(isStoreEmployee = false, events = makeApi().events, leaderboard = makeApi().leaderboard) {
+    mockApi.getAllEvents.mockReturnValue(of(events));
+    mockApi.getLeaderboard.mockReturnValue(of(leaderboard));
+
+    TestBed.configureTestingModule({
+      imports: [LandingComponent, NoopAnimationsModule],
+      providers: [
+        provideRouter([]),
+        { provide: ApiService, useValue: mockApi },
+        { provide: AuthService, useValue: makeAuthService(isStoreEmployee) },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LandingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows "Find Events" heading', () => {
+    setup();
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('h2')?.textContent).toContain('Find Events');
+  });
+
+  it('shows "Featured Events" subheading', () => {
+    setup();
+    const el: HTMLElement = fixture.nativeElement;
+    const h3 = Array.from(el.querySelectorAll('h3')).find(h => h.textContent?.includes('Featured Events'));
+    expect(h3).toBeTruthy();
+  });
+
+  it('renders a card for each Registration-status event', () => {
+    const events = [
+      makeEventDto({ id: 1, status: 'Registration' }),
+      makeEventDto({ id: 2, status: 'Registration' }),
+    ];
+    setup(false, events);
+    const cards = fixture.nativeElement.querySelectorAll('mat-card.event-card');
+    expect(cards.length).toBe(2);
+  });
+
+  it('does NOT render InProgress events in featured list', () => {
+    const events = [
+      makeEventDto({ id: 1, status: 'Registration' }),
+      makeEventDto({ id: 2, status: 'InProgress' }),
+    ];
+    setup(false, events);
+    const cards = fixture.nativeElement.querySelectorAll('mat-card.event-card');
+    expect(cards.length).toBe(1);
+  });
+
+  it('event card shows the event name', () => {
+    const events = [makeEventDto({ id: 1, status: 'Registration', name: 'Grand Prix Test' })];
+    setup(false, events);
+    const card: HTMLElement = fixture.nativeElement.querySelector('mat-card.event-card');
+    expect(card.querySelector('.event-name')?.textContent).toContain('Grand Prix Test');
+  });
+
+  it('event card links to /events/:id', () => {
+    const events = [makeEventDto({ id: 42, status: 'Registration' })];
+    setup(false, events);
+    const cardDe = fixture.debugElement.query(By.css('mat-card.event-card'));
+    const rl = cardDe.injector.get(RouterLink) as any;
+    // Angular 15+ stores commands as a private field; check all own keys for the array containing 42
+    const found = Object.keys(rl).some(k => {
+      try { return JSON.stringify(rl[k])?.includes('42'); } catch { return false; }
+    });
+    expect(found).toBe(true);
+  });
+
+  it('shows "No upcoming events" when featured list is empty', () => {
+    setup(false, []);
+    const el: HTMLElement = fixture.nativeElement;
+    expect(el.querySelector('.empty-state')?.textContent).toContain('No upcoming events');
+  });
+
+  it('shows "Top Players" heading', () => {
+    setup();
+    const el: HTMLElement = fixture.nativeElement;
+    const h2s = Array.from(el.querySelectorAll('h2'));
+    expect(h2s.some(h => h.textContent?.includes('Top Players'))).toBe(true);
+  });
+
+  it('renders up to 5 leaderboard rows', () => {
+    const entries = Array.from({ length: 7 }, (_, i) =>
+      makeLeaderboardEntry({ rank: i + 1, playerId: i + 1 })
+    );
+    setup(false, [], entries);
+    const rows = fixture.nativeElement.querySelectorAll('tr.leaderboard-row');
+    expect(rows.length).toBe(5);
+  });
+
+  it('"View Full Leaderboard" link is present', () => {
+    setup();
+    const el: HTMLElement = fixture.nativeElement;
+    const link = Array.from(el.querySelectorAll('a')).find(a => a.textContent?.includes('View Full Leaderboard'));
+    expect(link).toBeTruthy();
+  });
+
+  it('"Host a Tournament" button is visible when isStoreEmployee = true', () => {
+    setup(true);
+    const el: HTMLElement = fixture.nativeElement;
+    const btn = Array.from(el.querySelectorAll('button, a')).find(b => b.textContent?.trim().includes('Host a Tournament'));
+    expect(btn).toBeTruthy();
+  });
+
+  it('"Host a Tournament" button is NOT visible when isStoreEmployee = false', () => {
+    setup(false);
+    const el: HTMLElement = fixture.nativeElement;
+    const btn = Array.from(el.querySelectorAll('button, a')).find(b => b.textContent?.trim().includes('Host a Tournament'));
+    expect(btn).toBeFalsy();
+  });
+});
+
+function makeApi() {
+  return { events: [] as ReturnType<typeof makeEventDto>[], leaderboard: [] as ReturnType<typeof makeLeaderboardEntry>[] };
+}

--- a/tournament-client/src/app/features/landing/landing.component.ts
+++ b/tournament-client/src/app/features/landing/landing.component.ts
@@ -1,0 +1,137 @@
+import { Component, OnInit, ChangeDetectorRef, inject } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { forkJoin } from 'rxjs';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatChipsModule } from '@angular/material/chips';
+import { MatIconModule } from '@angular/material/icon';
+import { ApiService } from '../../core/services/api.service';
+import { AuthService } from '../../core/services/auth.service';
+import { EventDto, LeaderboardEntry, POINT_SYSTEM_LABELS, PointSystem } from '../../core/models/api.models';
+
+@Component({
+  selector: 'app-landing',
+  standalone: true,
+  imports: [CommonModule, RouterLink, MatButtonModule, MatCardModule, MatChipsModule, MatIconModule],
+  template: `
+    <div class="landing-hero">
+      <h1>Commander Tournament Organizer</h1>
+      <p class="hero-sub">Track your TrueSkill rating, compete in pods, and climb the leaderboard.</p>
+      <div class="hero-actions">
+        <a mat-raised-button color="primary" routerLink="/events">Browse Events</a>
+        @if (authService.isStoreEmployee) {
+          <a mat-stroked-button routerLink="/events">Host a Tournament</a>
+        }
+      </div>
+    </div>
+
+    <section class="landing-section">
+      <h2>Find Events</h2>
+      <h3>Featured Events</h3>
+
+      @if (featuredEvents.length === 0) {
+        <p class="empty-state">No upcoming events</p>
+      } @else {
+        <div class="event-cards">
+          @for (evt of featuredEvents; track evt.id) {
+            <mat-card class="event-card" [routerLink]="['/events', evt.id]">
+              <div class="event-card-image">
+                <mat-icon>event</mat-icon>
+              </div>
+              <mat-card-content>
+                <h4 class="event-name">{{ evt.name }}</h4>
+                <mat-chip-set>
+                  <mat-chip>{{ pointLabel(evt.pointSystem) }}</mat-chip>
+                </mat-chip-set>
+                <div class="event-meta">
+                  <mat-icon>calendar_today</mat-icon> {{ evt.date | date:'mediumDate' }}
+                </div>
+                @if (evt.storeName) {
+                  <div class="event-meta"><mat-icon>location_on</mat-icon> {{ evt.storeName }}</div>
+                }
+                <div class="event-meta">
+                  <mat-icon>person</mat-icon> {{ evt.playerCount }} registered
+                </div>
+              </mat-card-content>
+            </mat-card>
+          }
+        </div>
+      }
+    </section>
+
+    <section class="landing-section">
+      <h2>Top Players</h2>
+      <table>
+        <tbody>
+          @for (entry of leaderboard.slice(0, 5); track entry.playerId) {
+            <tr class="leaderboard-row">
+              <td>{{ entry.rank }}</td>
+              <td><a [routerLink]="['/players', entry.playerId]">{{ entry.name }}</a></td>
+              <td>{{ entry.conservativeScore | number:'1.1-1' }}</td>
+            </tr>
+          }
+        </tbody>
+      </table>
+      <a routerLink="/leaderboard">View Full Leaderboard</a>
+    </section>
+  `,
+  styles: [`
+    .landing-hero {
+      padding: 48px 24px;
+      text-align: center;
+    }
+    h1 { font-size: 2rem; margin-bottom: 8px; }
+    .hero-sub { margin-bottom: 24px; color: rgba(0,0,0,.6); }
+    .hero-actions { display: flex; gap: 12px; justify-content: center; flex-wrap: wrap; }
+    .landing-section { padding: 24px; }
+    .event-cards { display: flex; flex-wrap: wrap; gap: 16px; }
+    .event-card { width: 260px; cursor: pointer; }
+    .event-card-image {
+      height: 120px;
+      background: rgba(0,0,0,.08);
+      display: flex; align-items: center; justify-content: center;
+    }
+    .event-card-image mat-icon { font-size: 48px; width: 48px; height: 48px; }
+    .event-name { margin: 8px 0 4px; }
+    .event-meta { display: flex; align-items: center; gap: 4px; font-size: 0.85rem; margin-top: 4px; }
+    .event-meta mat-icon { font-size: 14px; width: 14px; height: 14px; }
+    .empty-state { color: rgba(0,0,0,.5); font-style: italic; }
+    table { width: 100%; border-collapse: collapse; }
+    tr.leaderboard-row td { padding: 6px 8px; }
+  `]
+})
+export class LandingComponent implements OnInit {
+  events: EventDto[] = [];
+  leaderboard: LeaderboardEntry[] = [];
+
+  private api = inject(ApiService);
+  authService = inject(AuthService);
+  private cdr = inject(ChangeDetectorRef);
+
+  get featuredEvents(): EventDto[] {
+    return this.events
+      .filter(e => e.status === 'Registration')
+      .sort((a, b) => a.date.localeCompare(b.date));
+  }
+
+  ngOnInit(): void {
+    forkJoin({
+      events: this.api.getAllEvents(),
+      leaderboard: this.api.getLeaderboard(),
+    }).subscribe({
+      next: ({ events, leaderboard }) => {
+        this.events = events;
+        this.leaderboard = leaderboard;
+        this.cdr.detectChanges();
+      },
+      error: () => {
+        this.cdr.detectChanges();
+      }
+    });
+  }
+
+  pointLabel(ps: PointSystem): string {
+    return POINT_SYSTEM_LABELS[ps] ?? ps;
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `LandingComponent` at `/` — replaces the old redirect to `/leaderboard`
- Hero section with app name, **Browse Events** CTA, and **Host a Tournament** button (StoreEmployee/StoreManager/Administrator only)
- **Featured Events** section: `Registration`-status events sorted by date, image-ready card layout with placeholder
- **Leaderboard Preview** section: top 5 entries from `GET /api/leaderboard` with a View Full Leaderboard link
- **Home** nav link added as first sidenav item (`exact: true` active matching)

## Test plan
- [x] 12 Jest unit tests (`landing.component.spec.ts`) — all pass
- [x] 11 Playwright E2E tests (`e2e/landing/landing.spec.ts`) — all pass
- [x] `/build` — 0 errors
- [x] `/check-zone` — clean (both `next:` and `error:` callbacks call `cdr.detectChanges()`)
- [x] Full Jest suite — no regressions (pre-existing `event.service.spec.ts` failures unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)