### PR TITLE
feat: bulk player registration for events

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/EventsController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/EventsController.cs
@@ -260,6 +260,14 @@ public class EventsController : ControllerBase
         catch (InvalidOperationException ex) { return BadRequest(new { error = ex.Message }); }
     }
 
+    [HttpPost("{id}/bulkregister/confirm")]
+    [Authorize]
+    public async Task<ActionResult<BulkRegisterResultDto>> BulkRegisterConfirm(int id, BulkRegisterConfirmDto dto)
+    {
+        if (!await UserCanManageEvent(id)) return Forbid();
+        return Ok(await _eventService.BulkRegisterConfirmAsync(id, dto));
+    }
+
     [HttpPost("checkin/{token}")]
     [Authorize]
     public async Task<ActionResult<CheckInResponseDto>> CheckInByToken(string token)

--- a/src/TournamentOrganizer.Api/DTOs/EventDto.cs
+++ b/src/TournamentOrganizer.Api/DTOs/EventDto.cs
@@ -52,3 +52,16 @@ public record DeclareCommanderDto(string? Commanders, string? DecklistUrl);
 public record PodPlayerPairingsDto(int PlayerId, string Name, string? CommanderName, int SeatOrder = 0);
 public record PodPairingsDto(int PodId, int PodNumber, List<PodPlayerPairingsDto> Players, string GameStatus = "Pending", int? WinnerPlayerId = null);
 public record PairingsDto(int EventId, string EventName, int? CurrentRound, List<PodPairingsDto> Pods);
+
+// ── Bulk register ────────────────────────────────────────────────────────────
+
+public record BulkRegisterConfirmDto(List<BulkRegisterConfirmItemDto> Registrations);
+
+public record BulkRegisterConfirmItemDto(
+    int?    PlayerId,   // null when creating a new player
+    string  Email,
+    string? Name        // required when PlayerId is null
+);
+
+public record BulkRegisterResultDto(int Registered, int Created, List<BulkRegisterErrorDto> Errors);
+public record BulkRegisterErrorDto(string Email, string Reason);

--- a/src/TournamentOrganizer.Api/Services/EventService.cs
+++ b/src/TournamentOrganizer.Api/Services/EventService.cs
@@ -849,4 +849,54 @@ public class EventService : IEventService
             registration.IsDropped, registration.IsDisqualified, registration.IsCheckedIn,
             registration.DroppedAfterRound, registration.IsWaitlisted, registration.WaitlistPosition);
     }
+
+    public async Task<BulkRegisterResultDto> BulkRegisterConfirmAsync(int eventId, BulkRegisterConfirmDto dto)
+    {
+        int registered = 0;
+        int created = 0;
+        var errors = new List<BulkRegisterErrorDto>();
+
+        foreach (var item in dto.Registrations)
+        {
+            try
+            {
+                int playerId;
+
+                if (item.PlayerId == null)
+                {
+                    // New player — name is required
+                    if (string.IsNullOrWhiteSpace(item.Name))
+                    {
+                        errors.Add(new BulkRegisterErrorDto(item.Email, "Name is required to create a new player."));
+                        continue;
+                    }
+
+                    var newPlayer = await _playerRepo.CreateAsync(new Player
+                    {
+                        Name = item.Name,
+                        Email = item.Email,
+                        PlacementGamesLeft = 5,
+                        Mu = 25.0,
+                        Sigma = 8.333,
+                        IsActive = true,
+                    });
+                    playerId = newPlayer.Id;
+                    created++;
+                }
+                else
+                {
+                    playerId = item.PlayerId.Value;
+                }
+
+                await RegisterPlayerAsync(eventId, playerId);
+                registered++;
+            }
+            catch (Exception ex)
+            {
+                errors.Add(new BulkRegisterErrorDto(item.Email, ex.Message));
+            }
+        }
+
+        return new BulkRegisterResultDto(registered, created, errors);
+    }
 }

--- a/src/TournamentOrganizer.Api/Services/Interfaces/IEventService.cs
+++ b/src/TournamentOrganizer.Api/Services/Interfaces/IEventService.cs
@@ -25,4 +25,5 @@ public interface IEventService
     Task<PairingsDto?> GetPairingsAsync(int eventId);
     Task<CheckInResponseDto> CheckInByTokenAsync(string token, string playerEmail);
     Task<EventPlayerDto> DeclareCommanderAsync(int eventId, int playerId, DeclareCommanderDto dto);
+    Task<BulkRegisterResultDto> BulkRegisterConfirmAsync(int eventId, BulkRegisterConfirmDto dto);
 }

--- a/src/TournamentOrganizer.Tests/EventBulkRegisterTests.cs
+++ b/src/TournamentOrganizer.Tests/EventBulkRegisterTests.cs
@@ -1,0 +1,249 @@
+using TournamentOrganizer.Api.DTOs;
+using TournamentOrganizer.Api.Models;
+using TournamentOrganizer.Api.Repositories.Interfaces;
+using TournamentOrganizer.Api.Services;
+using TournamentOrganizer.Api.Services.Interfaces;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// TDD tests for the BulkRegisterConfirmAsync feature.
+/// </summary>
+public class EventBulkRegisterTests
+{
+    // ── Fake repositories ────────────────────────────────────────────────
+
+    private sealed class FakeEventRepository : IEventRepository
+    {
+        public List<Event> Events { get; } = [];
+        public List<EventRegistration> Registrations { get; } = [];
+
+        public Task<Event?> GetByIdAsync(int id) =>
+            Task.FromResult(Events.FirstOrDefault(e => e.Id == id));
+        public Task<EventRegistration?> GetRegistrationAsync(int eid, int pid) =>
+            Task.FromResult(Registrations.FirstOrDefault(r => r.EventId == eid && r.PlayerId == pid));
+        public Task<bool> IsPlayerRegisteredAsync(int eventId, int playerId) =>
+            Task.FromResult(Registrations.Any(r => r.EventId == eventId && r.PlayerId == playerId && !r.IsDropped && !r.IsDisqualified));
+        public Task<EventRegistration> RegisterPlayerAsync(EventRegistration r)
+        {
+            Registrations.Add(r);
+            return Task.FromResult(r);
+        }
+        public Task<List<EventRegistration>> GetRegistrationsWithPlayersAsync(int eventId) =>
+            Task.FromResult(Registrations.Where(r => r.EventId == eventId).ToList());
+        public Task UpdateRegistrationAsync(EventRegistration r)
+        {
+            var idx = Registrations.FindIndex(x => x.EventId == r.EventId && x.PlayerId == r.PlayerId);
+            if (idx >= 0) Registrations[idx] = r;
+            return Task.CompletedTask;
+        }
+
+        // stubs
+        public Task<Event?> GetByCheckInTokenAsync(string token)                        => Task.FromResult<Event?>(null);
+        public Task<Round?> GetLatestRoundAsync(int eventId)                            => Task.FromResult<Round?>(null);
+        public Task<List<Player>> GetRegisteredPlayersAsync(int eventId)                => Task.FromResult(new List<Player>());
+        public Task<Event?> GetWithDetailsAsync(int id)                                 => Task.FromResult<Event?>(null);
+        public Task<List<Event>> GetAllAsync()                                          => Task.FromResult(new List<Event>());
+        public Task<List<Event>> GetAllWithStoreAsync(int? storeId = null)              => Task.FromResult(new List<Event>());
+        public Task<Event> CreateAsync(Event evt)                                       => Task.FromResult(evt);
+        public Task UpdateAsync(Event evt)                                              => Task.CompletedTask;
+        public Task<Round> CreateRoundAsync(Round round)                                => Task.FromResult(round);
+        public Task<Round?> GetLatestRoundWithPairingsAsync(int eventId)                => Task.FromResult<Round?>(null);
+        public Task<Round?> GetRoundWithDetailsAsync(int roundId)                       => Task.FromResult<Round?>(null);
+        public Task<List<Round>> GetRoundsForEventAsync(int eventId)                    => Task.FromResult(new List<Round>());
+        public Task RemoveRegistrationAsync(EventRegistration r)                        => Task.CompletedTask;
+    }
+
+    private sealed class FakePlayerRepository : IPlayerRepository
+    {
+        private readonly List<Player> _players = [];
+        private int _nextId = 100;
+
+        public void Seed(Player p) => _players.Add(p);
+
+        public Task<Player?> GetByIdAsync(int id) =>
+            Task.FromResult(_players.FirstOrDefault(p => p.Id == id));
+        public Task<Player?> GetByEmailAsync(string email) =>
+            Task.FromResult(_players.FirstOrDefault(p =>
+                string.Equals(p.Email, email, StringComparison.OrdinalIgnoreCase)));
+        public Task<Player> CreateAsync(Player p)
+        {
+            if (p.Id == 0) p.Id = _nextId++;
+            _players.Add(p);
+            return Task.FromResult(p);
+        }
+        public Task UpdateAsync(Player p) => Task.CompletedTask;
+        public Task UpdateRangeAsync(IEnumerable<Player> ps) => Task.CompletedTask;
+
+        // stubs
+        public Task<List<Player>> GetLeaderboardAsync()                                 => Task.FromResult(new List<Player>());
+        public Task<List<Player>> GetAllAsync()                                         => Task.FromResult(new List<Player>());
+        public Task<List<Player>> GetByIdsAsync(IEnumerable<int> ids)                  => Task.FromResult(new List<Player>());
+        public Task<List<EventRegistration>> GetPlayerEventRegistrationsAsync(int pid) => Task.FromResult(new List<EventRegistration>());
+    }
+
+    private sealed class StubGameRepo : IGameRepository
+    {
+        public Task<Game?> GetByIdAsync(int id)                                            => Task.FromResult<Game?>(null);
+        public Task<Game?> GetWithResultsAsync(int id)                                     => Task.FromResult<Game?>(null);
+        public Task<Game> CreateAsync(Game g)                                              => Task.FromResult(g);
+        public Task UpdateAsync(Game g)                                                    => Task.CompletedTask;
+        public Task AddResultsAsync(IEnumerable<GameResult> r)                             => Task.CompletedTask;
+        public Task DeleteResultsAsync(int gameId)                                         => Task.CompletedTask;
+        public Task<List<GameResult>> GetPlayerResultsAsync(int pid)                       => Task.FromResult(new List<GameResult>());
+        public Task<List<GameResult>> GetPlayerGamesWithOpponentsAsync(int pid)            => Task.FromResult(new List<GameResult>());
+        public Task<List<int>> GetPreviousOpponentIdsAsync(int eid, int pid)               => Task.FromResult(new List<int>());
+        public Task<List<GameResult>> GetStoreGameResultsAsync(int storeId, DateTime? since) => Task.FromResult(new List<GameResult>());
+    }
+
+    private sealed class StubPodService : IPodService
+    {
+        public List<List<Player>> GenerateRound1Pods(List<Player> players) => [players];
+        public List<List<Player>> GenerateNextRoundPods(Round previousRound, List<Player> activePlayers) => [activePlayers];
+    }
+
+    private sealed class StubTrueSkillService : ITrueSkillService
+    {
+        public Task UpdateRatingsAsync(Game game) => Task.CompletedTask;
+        public Task UpdateRatingsFromEventStandingsAsync(List<(int PlayerId, int Rank, int GamesPlayed)> rankings) => Task.CompletedTask;
+    }
+
+    private sealed class StubDiscordWebhookService : IDiscordWebhookService
+    {
+        public Task PostRoundResultsAsync(int eventId, int roundNumber) => Task.CompletedTask;
+        public Task PostEventCompletedAsync(int eventId) => Task.CompletedTask;
+        public Task PostPlayerRankedAsync(int playerId, int eventId) => Task.CompletedTask;
+        public Task PostTestMessageAsync(int storeId) => Task.CompletedTask;
+    }
+
+    private sealed class StubStoreEventRepo : IStoreEventRepository
+    {
+        public Task AddAsync(StoreEvent se) => Task.CompletedTask;
+        public Task<int?> GetStoreIdForEventAsync(int eventId) => Task.FromResult<int?>(null);
+        public Task<(int? StoreId, string? StoreName)> GetStoreInfoForEventAsync(int eventId) => Task.FromResult<(int?, string?)>((null, null));
+        public Task<List<StoreEvent>> GetByStoreIdAsync(int storeId) => Task.FromResult(new List<StoreEvent>());
+    }
+
+    private static EventService BuildService(FakeEventRepository eventRepo, FakePlayerRepository playerRepo) =>
+        new(eventRepo, playerRepo, new StubGameRepo(), new StubPodService(), new StubTrueSkillService(), new StubStoreEventRepo(), new StubDiscordWebhookService());
+
+    private static Player MakePlayer(int id, string email) =>
+        new() { Id = id, Name = $"Player{id}", Email = email, Mu = 25, Sigma = 8.333 };
+
+    // ── Tests ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BulkRegisterConfirmAsync_RegistersExistingPlayer()
+    {
+        var eventRepo = new FakeEventRepository();
+        eventRepo.Events.Add(new Event { Id = 1, Status = EventStatus.Registration });
+
+        var playerRepo = new FakePlayerRepository();
+        playerRepo.Seed(MakePlayer(10, "alice@example.com"));
+
+        var svc = BuildService(eventRepo, playerRepo);
+        var dto = new BulkRegisterConfirmDto([
+            new BulkRegisterConfirmItemDto(10, "alice@example.com", null)
+        ]);
+
+        var result = await svc.BulkRegisterConfirmAsync(1, dto);
+
+        Assert.Equal(1, result.Registered);
+        Assert.Equal(0, result.Created);
+        Assert.Empty(result.Errors);
+        Assert.Single(eventRepo.Registrations, r => r.PlayerId == 10);
+    }
+
+    [Fact]
+    public async Task BulkRegisterConfirmAsync_CreatesNewPlayerForUnknownEmail()
+    {
+        var eventRepo = new FakeEventRepository();
+        eventRepo.Events.Add(new Event { Id = 1, Status = EventStatus.Registration });
+
+        var playerRepo = new FakePlayerRepository();
+
+        var svc = BuildService(eventRepo, playerRepo);
+        var dto = new BulkRegisterConfirmDto([
+            new BulkRegisterConfirmItemDto(null, "new@example.com", "New Player")
+        ]);
+
+        var result = await svc.BulkRegisterConfirmAsync(1, dto);
+
+        Assert.Equal(1, result.Registered);
+        Assert.Equal(1, result.Created);
+        Assert.Empty(result.Errors);
+        // Exactly one registration should have been created
+        Assert.Single(eventRepo.Registrations);
+    }
+
+    [Fact]
+    public async Task BulkRegisterConfirmAsync_SkipsAlreadyRegistered_ReturnsError()
+    {
+        var eventRepo = new FakeEventRepository();
+        eventRepo.Events.Add(new Event { Id = 1, Status = EventStatus.Registration });
+        eventRepo.Registrations.Add(new EventRegistration { EventId = 1, PlayerId = 10 });
+
+        var playerRepo = new FakePlayerRepository();
+        playerRepo.Seed(MakePlayer(10, "alice@example.com"));
+
+        var svc = BuildService(eventRepo, playerRepo);
+        var dto = new BulkRegisterConfirmDto([
+            new BulkRegisterConfirmItemDto(10, "alice@example.com", null)
+        ]);
+
+        var result = await svc.BulkRegisterConfirmAsync(1, dto);
+
+        Assert.Equal(0, result.Registered);
+        Assert.Equal(0, result.Created);
+        Assert.Single(result.Errors);
+        Assert.Equal("alice@example.com", result.Errors[0].Email);
+    }
+
+    [Fact]
+    public async Task BulkRegisterConfirmAsync_MissingNameForNewPlayer_ReturnsError()
+    {
+        var eventRepo = new FakeEventRepository();
+        eventRepo.Events.Add(new Event { Id = 1, Status = EventStatus.Registration });
+
+        var playerRepo = new FakePlayerRepository();
+
+        var svc = BuildService(eventRepo, playerRepo);
+        var dto = new BulkRegisterConfirmDto([
+            new BulkRegisterConfirmItemDto(null, "nameless@example.com", null) // no name
+        ]);
+
+        var result = await svc.BulkRegisterConfirmAsync(1, dto);
+
+        Assert.Equal(0, result.Registered);
+        Assert.Equal(0, result.Created);
+        Assert.Single(result.Errors);
+        Assert.Equal("nameless@example.com", result.Errors[0].Email);
+    }
+
+    [Fact]
+    public async Task BulkRegisterConfirmAsync_PartialSuccess_ReturnsCountsAndErrors()
+    {
+        var eventRepo = new FakeEventRepository();
+        eventRepo.Events.Add(new Event { Id = 1, Status = EventStatus.Registration });
+        // Player 10 already registered
+        eventRepo.Registrations.Add(new EventRegistration { EventId = 1, PlayerId = 10 });
+
+        var playerRepo = new FakePlayerRepository();
+        playerRepo.Seed(MakePlayer(10, "alice@example.com")); // already registered → error
+        playerRepo.Seed(MakePlayer(11, "bob@example.com"));   // not registered → success
+
+        var svc = BuildService(eventRepo, playerRepo);
+        var dto = new BulkRegisterConfirmDto([
+            new BulkRegisterConfirmItemDto(10, "alice@example.com", null),    // will error
+            new BulkRegisterConfirmItemDto(11, "bob@example.com", null),      // will succeed
+            new BulkRegisterConfirmItemDto(null, "new@example.com", "New"),   // create + register
+        ]);
+
+        var result = await svc.BulkRegisterConfirmAsync(1, dto);
+
+        Assert.Equal(2, result.Registered);
+        Assert.Equal(1, result.Created);
+        Assert.Single(result.Errors);
+        Assert.Equal("alice@example.com", result.Errors[0].Email);
+    }
+}

--- a/tournament-client/e2e/events/event-detail.spec.ts
+++ b/tournament-client/e2e/events/event-detail.spec.ts
@@ -11,8 +11,10 @@ import {
   mockSetPlayerDropped,
   mockPromoteFromWaitlist,
   mockDeclareCommander,
+  mockBulkRegisterConfirm,
   makeEventDto,
   makeEventPlayerDto,
+  makeBulkRegisterResultDto,
 } from '../helpers/api-mock';
 
 // ─── Event Detail — Check-In ──────────────────────────────────────────────────
@@ -456,5 +458,232 @@ test.describe('Commander Declaration: role gate', () => {
 
   test('edit icon NOT visible on another player row', async ({ page }) => {
     await expect(page.getByTitle('Edit commander')).not.toBeVisible();
+  });
+});
+
+// ── Bulk Register ─────────────────────────────────────────────────────────────
+//
+// Player data is seeded into localStorage BEFORE navigation via addInitScript.
+// The localStorage key format is to_store_<storeId>_players.
+
+const ALICE_STORE_PLAYER = { id: 10, name: 'Alice Manager', email: 'alice@shop.com', mu: 25, sigma: 8.333, conservativeScore: 0, isRanked: false, placementGamesLeft: 5, isActive: true };
+const BOB_STORE_PLAYER   = { id: 11, name: 'Bob Player',    email: 'bob@example.com', mu: 25, sigma: 8.333, conservativeScore: 0, isRanked: false, placementGamesLeft: 5, isActive: true };
+
+/** Seed players into localStorage for store 1 before page load. */
+async function seedStorePlayers(page: import('@playwright/test').Page, players: typeof ALICE_STORE_PLAYER[]) {
+  await page.addInitScript((p) => {
+    localStorage.setItem('to_store_1_players', JSON.stringify(p));
+    localStorage.setItem('to_store_1_players_meta', JSON.stringify([]));
+  }, players);
+}
+
+test.describe('Bulk Register: upload file — visibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER, BOB_STORE_PLAYER]);
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+    await page.goto(`/events/${EVENT_ID}`);
+  });
+
+  test('Upload File button is visible for StoreEmployee during Registration', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /upload file/i })).toBeVisible();
+  });
+
+  test('hidden file input for .txt/.csv is present', async ({ page }) => {
+    await expect(page.locator('input[type="file"][accept=".txt,.csv"]')).toBeAttached();
+  });
+
+  test('multi-select list renders store players', async ({ page }) => {
+    await expect(page.getByText('Alice Manager')).toBeVisible();
+    await expect(page.getByText('Bob Player')).toBeVisible();
+  });
+});
+
+test.describe('Bulk Register: upload file — preview panel', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER, BOB_STORE_PLAYER]);
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+
+    // Upload a file containing alice (found) and unknown@new.com (not found)
+    await page.addInitScript(() => {
+      // Override FileReader so it loads the fake CSV synchronously
+      (window as any).__fakeFileContent = 'alice@shop.com\nunknown@new.com';
+    });
+
+    await page.goto(`/events/${EVENT_ID}`);
+
+    // Trigger file selection by dispatching a synthetic change event via evaluate
+    await page.locator('input[type="file"][accept=".txt,.csv"]').evaluate((input: HTMLInputElement) => {
+      const content = (window as any).__fakeFileContent ?? '';
+      const file = new File([content], 'players.txt', { type: 'text/plain' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      Object.defineProperty(input, 'files', { value: dataTransfer.files });
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+
+  test('Preview Registration heading appears after file upload', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Preview Registration', level: 3 })).toBeVisible();
+  });
+
+  test('"Will register" section lists alice', async ({ page }) => {
+    await expect(page.locator('.bulk-preview-panel')).toContainText('alice@shop.com');
+  });
+
+  test('"New players to create" section shows unknown email with name input', async ({ page }) => {
+    await expect(page.locator('.bulk-preview-panel')).toContainText('New players to create');
+    await expect(page.getByLabel('Name for unknown@new.com')).toBeVisible();
+  });
+});
+
+test.describe('Bulk Register: confirm', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER]);
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+    await mockBulkRegisterConfirm(page, EVENT_ID, makeBulkRegisterResultDto({ registered: 2, created: 1 }));
+
+    await page.addInitScript(() => {
+      (window as any).__fakeFileContent = 'alice@shop.com';
+    });
+
+    await page.goto(`/events/${EVENT_ID}`);
+
+    await page.locator('input[type="file"][accept=".txt,.csv"]').evaluate((input: HTMLInputElement) => {
+      const content = (window as any).__fakeFileContent ?? '';
+      const file = new File([content], 'players.txt', { type: 'text/plain' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      Object.defineProperty(input, 'files', { value: dataTransfer.files });
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+
+  test('clicking Confirm Registration shows summary snackbar', async ({ page }) => {
+    await page.getByRole('button', { name: 'Confirm Registration' }).click();
+    await expect(page.getByText(/2 registered/)).toBeVisible();
+  });
+
+  test('preview panel is hidden after confirm', async ({ page }) => {
+    await page.getByRole('button', { name: 'Confirm Registration' }).click();
+    await expect(page.getByRole('heading', { name: 'Preview Registration', level: 3 })).not.toBeVisible();
+  });
+});
+
+test.describe('Bulk Register: cancel', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER]);
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+
+    await page.addInitScript(() => {
+      (window as any).__fakeFileContent = 'alice@shop.com';
+    });
+
+    await page.goto(`/events/${EVENT_ID}`);
+
+    await page.locator('input[type="file"][accept=".txt,.csv"]').evaluate((input: HTMLInputElement) => {
+      const content = (window as any).__fakeFileContent ?? '';
+      const file = new File([content], 'players.txt', { type: 'text/plain' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      Object.defineProperty(input, 'files', { value: dataTransfer.files });
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+
+  test('clicking Cancel hides the preview panel', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Preview Registration', level: 3 })).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('heading', { name: 'Preview Registration', level: 3 })).not.toBeVisible();
+  });
+});
+
+test.describe('Bulk Register: multi-select', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER, BOB_STORE_PLAYER]);
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+    await page.goto(`/events/${EVENT_ID}`);
+  });
+
+  test('Select All button checks all players and enables Register Selected', async ({ page }) => {
+    await page.getByRole('button', { name: 'Select All', exact: true }).click();
+    // Register Selected should now be enabled
+    await expect(page.getByRole('button', { name: 'Register Selected' })).not.toBeDisabled();
+  });
+
+  test('clicking Register Selected shows preview panel', async ({ page }) => {
+    await page.getByRole('button', { name: 'Select All', exact: true }).click();
+    await page.getByRole('button', { name: 'Register Selected' }).click();
+    await expect(page.getByRole('heading', { name: 'Preview Registration', level: 3 })).toBeVisible();
+  });
+});
+
+test.describe('Bulk Register: already registered', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER]);
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    // Alice is already registered
+    await mockGetEventPlayers(page, EVENT_ID, [makeEventPlayerDto({ playerId: ALICE_STORE_PLAYER.id, name: ALICE_STORE_PLAYER.name })]);
+
+    await page.addInitScript(() => {
+      (window as any).__fakeFileContent = 'alice@shop.com';
+    });
+
+    await page.goto(`/events/${EVENT_ID}`);
+
+    await page.locator('input[type="file"][accept=".txt,.csv"]').evaluate((input: HTMLInputElement) => {
+      const content = (window as any).__fakeFileContent ?? '';
+      const file = new File([content], 'players.txt', { type: 'text/plain' });
+      const dataTransfer = new DataTransfer();
+      dataTransfer.items.add(file);
+      Object.defineProperty(input, 'files', { value: dataTransfer.files });
+      input.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+  });
+
+  test('already-registered player appears in the skipped section', async ({ page }) => {
+    await expect(page.locator('.bulk-preview-panel')).toContainText('Already registered (skipped)');
+    await expect(page.locator('.bulk-preview-panel')).toContainText('alice@shop.com');
+  });
+});
+
+test.describe('Bulk Register: role gate', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'Player', { playerId: 99 });
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, REG_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+    await page.goto(`/events/${EVENT_ID}`);
+  });
+
+  test('Upload File button is NOT visible for Player role', async ({ page }) => {
+    await expect(page.getByRole('button', { name: /upload file/i })).not.toBeVisible();
+  });
+
+  test('multi-select section is NOT visible for Player role', async ({ page }) => {
+    await expect(page.getByRole('button', { name: 'Select All', exact: true })).not.toBeVisible();
   });
 });

--- a/tournament-client/e2e/helpers/api-mock.ts
+++ b/tournament-client/e2e/helpers/api-mock.ts
@@ -1,5 +1,5 @@
 import { Page } from '@playwright/test';
-import { CheckInResponseDto, CommanderMetaEntryDto, CommanderMetaReportDto, CommanderStatDto, EventDto, EventPlayerDto, LeaderboardEntry, PairingsDto, PlayerCommanderStatsDto, PlayerDto, PlayerProfile, StoreDto, StoreDetailDto, ThemeDto } from '../../src/app/core/models/api.models';
+import { BulkRegisterResultDto, CheckInResponseDto, CommanderMetaEntryDto, CommanderMetaReportDto, CommanderStatDto, EventDto, EventPlayerDto, LeaderboardEntry, PairingsDto, PlayerCommanderStatsDto, PlayerDto, PlayerProfile, StoreDto, StoreDetailDto, ThemeDto } from '../../src/app/core/models/api.models';
 
 /** Intercept GET /api/events and return the given list. */
 export async function mockGetEvents(page: Page, events: EventDto[]): Promise<void> {
@@ -422,6 +422,26 @@ export function makePairingsDto(overrides: Partial<PairingsDto> = {}): PairingsD
         ],
       },
     ],
+    ...overrides,
+  };
+}
+
+/** Intercept POST /api/events/:id/bulkregister/confirm and return the given result. */
+export async function mockBulkRegisterConfirm(page: Page, eventId: number, response: BulkRegisterResultDto): Promise<void> {
+  await page.route(`**/api/events/${eventId}/bulkregister/confirm`, route => {
+    if (route.request().method() === 'POST') {
+      route.fulfill({ json: response });
+    } else {
+      route.continue();
+    }
+  });
+}
+
+export function makeBulkRegisterResultDto(overrides: Partial<BulkRegisterResultDto> = {}): BulkRegisterResultDto {
+  return {
+    registered: 0,
+    created: 0,
+    errors: [],
     ...overrides,
   };
 }

--- a/tournament-client/src/app/core/models/api.models.ts
+++ b/tournament-client/src/app/core/models/api.models.ts
@@ -438,3 +438,23 @@ export interface StandingsEntry {
   finishPositions: number[];
   gameResults: string[];
 }
+
+// ── Bulk Register ──────────────────────────────────────────────────────────────
+
+/** Frontend-only: resolved player from local cache */
+export interface BulkRegisterFoundDto  { playerId: number; name: string; email: string; }
+
+/** Frontend-only: preview data built client-side before any API call */
+export interface BulkRegisterPreviewDto {
+  found:             BulkRegisterFoundDto[];
+  notFound:          string[];
+  alreadyRegistered: BulkRegisterFoundDto[];
+}
+
+/** Sent to POST /api/events/{id}/bulkregister/confirm */
+export interface BulkRegisterConfirmItemDto { playerId?: number | null; email: string; name?: string | null; }
+export interface BulkRegisterConfirmDto    { registrations: BulkRegisterConfirmItemDto[]; }
+
+/** Response from POST /api/events/{id}/bulkregister/confirm */
+export interface BulkRegisterResultDto     { registered: number; created: number; errors: { email: string; reason: string }[]; }
+

--- a/tournament-client/src/app/core/services/api.service.ts
+++ b/tournament-client/src/app/core/services/api.service.ts
@@ -11,7 +11,8 @@ import {
   StoreDto, StoreDetailDto, CreateStoreDto, UpdateStoreDto,
   SuggestedTradeDto, TradeCardDemandDto, WishlistCardSupplyDto,
   AppUserDto, AssignEmployeeDto,
-  LicenseDto, CreateLicenseDto, UpdateLicenseDto
+  LicenseDto, CreateLicenseDto, UpdateLicenseDto,
+  BulkRegisterConfirmDto, BulkRegisterResultDto,
 } from '../models/api.models';
 
 @Injectable({ providedIn: 'root' })
@@ -278,5 +279,9 @@ export class ApiService {
 
   getCommanderMeta(storeId: number, period: string = '30d'): Observable<CommanderMetaReportDto> {
     return this.http.get<CommanderMetaReportDto>(`${this.base}/stores/${storeId}/meta`, { params: { period } });
+  }
+
+  bulkRegisterConfirm(eventId: number, dto: BulkRegisterConfirmDto): Observable<BulkRegisterResultDto> {
+    return this.http.post<BulkRegisterResultDto>(`${this.base}/events/${eventId}/bulkregister/confirm`, dto);
   }
 }

--- a/tournament-client/src/app/features/events/event-detail.component.spec.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.spec.ts
@@ -8,8 +8,11 @@ import { EventDetailComponent } from './event-detail.component';
 import { EventService } from '../../core/services/event.service';
 import { PlayerService } from '../../core/services/player.service';
 import { AuthService } from '../../core/services/auth.service';
+import { ApiService } from '../../core/services/api.service';
+import { LocalStorageContext } from '../../core/services/local-storage-context.service';
 import {
   EventDto, EventPlayerDto, PlayerDto, RoundDto, StandingsEntry,
+  BulkRegisterConfirmDto, BulkRegisterResultDto,
 } from '../../core/models/api.models';
 
 describe('EventDetailComponent', () => {
@@ -71,8 +74,10 @@ describe('EventDetailComponent', () => {
     loadAllPlayers: jest.Mock;
   };
 
-  let mockSnackBar: { open: jest.Mock };
-  let mockRouter:   { navigate: jest.Mock };
+  let mockSnackBar:   { open: jest.Mock };
+  let mockRouter:     { navigate: jest.Mock };
+  let mockApiService: { bulkRegisterConfirm: jest.Mock };
+  let mockCtx:        { players: { getAll: jest.Mock; getById: jest.Mock } };
 
   async function setup(authOverrides: object = {}) {
     const mockAuth = {
@@ -91,11 +96,13 @@ describe('EventDetailComponent', () => {
           provide: ActivatedRoute,
           useValue: { snapshot: { paramMap: { get: jest.fn().mockReturnValue(String(EVENT_ID)) } } },
         },
-        { provide: Router,         useValue: mockRouter },
-        { provide: EventService,   useValue: mockEventService },
-        { provide: PlayerService,  useValue: mockPlayerService },
-        { provide: AuthService,    useValue: mockAuth },
-        { provide: MatSnackBar,    useValue: mockSnackBar },
+        { provide: Router,               useValue: mockRouter },
+        { provide: EventService,         useValue: mockEventService },
+        { provide: PlayerService,        useValue: mockPlayerService },
+        { provide: AuthService,          useValue: mockAuth },
+        { provide: MatSnackBar,          useValue: mockSnackBar },
+        { provide: ApiService,           useValue: mockApiService },
+        { provide: LocalStorageContext,  useValue: mockCtx },
       ],
     }).compileComponents();
   }
@@ -142,6 +149,8 @@ describe('EventDetailComponent', () => {
       createUrlTree: jest.fn().mockReturnValue({}),
       serializeUrl: jest.fn().mockReturnValue('/fake'),
     };
+    mockApiService = { bulkRegisterConfirm: jest.fn().mockReturnValue(of({ registered: 0, created: 0, errors: [] })) };
+    mockCtx = { players: { getAll: jest.fn().mockReturnValue([]), getById: jest.fn().mockReturnValue(null) } };
   });
 
   // ── Smoke ───────────────────────────────────────────────────────────────────
@@ -1020,6 +1029,261 @@ describe('EventDetailComponent', () => {
 
       expect(fixture.componentInstance.myRegistration?.playerId).toBe(5);
       expect(fixture.componentInstance.myRegistration?.isWaitlisted).toBe(true);
+    });
+  });
+
+  // ── Bulk Register ─────────────────────────────────────────────────────────
+
+  describe('Bulk Register', () => {
+    const regEvent: EventDto = { ...eventStub, status: 'Registration' };
+
+    const alicePlayer: PlayerDto = {
+      id: 10, name: 'Alice Manager', email: 'alice@shop.com',
+      mu: 25, sigma: 8.333, conservativeScore: 0, isRanked: false, placementGamesLeft: 5, isActive: true,
+    };
+
+    const bobPlayer: PlayerDto = {
+      id: 11, name: 'Bob Player', email: 'bob@example.com',
+      mu: 25, sigma: 8.333, conservativeScore: 0, isRanked: false, placementGamesLeft: 5, isActive: true,
+    };
+
+    // Fake FileReader that calls onload synchronously
+    let fakeFileContent = '';
+    class MockFileReader {
+      result: string = '';
+      onload: (() => void) | null = null;
+      readAsText(_file: File) {
+        this.result = fakeFileContent;
+        this.onload?.();
+      }
+    }
+
+    beforeEach(() => {
+      (global as any).FileReader = MockFileReader;
+    });
+
+    it('Upload File button is visible for StoreEmployee when event is in Registration', async () => {
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Upload File'));
+      expect(btn).toBeTruthy();
+    });
+
+    it('Upload File button is NOT visible for Player role', async () => {
+      await setup({ isStoreEmployee: false });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Upload File'));
+      expect(btn).toBeFalsy();
+    });
+
+    it('Register Selected button is disabled when no players checked', async () => {
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Register Selected')) as HTMLButtonElement | undefined;
+      expect(btn).toBeTruthy();
+      expect(btn?.disabled).toBe(true);
+    });
+
+    it('Register Selected button is enabled when at least one player is checked', async () => {
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const comp = fixture.componentInstance;
+      comp.selectedPlayerIds.add(alicePlayer.id);
+
+      // Verify the bound expression that controls disabled
+      expect(comp.selectedPlayerIds.size).toBeGreaterThan(0);
+    });
+
+    it('onBulkFileSelected resolves found players without calling apiService', async () => {
+      fakeFileContent = 'alice@shop.com\n';
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+
+      expect(mockApiService.bulkRegisterConfirm).not.toHaveBeenCalled();
+      expect(fixture.componentInstance.previewData?.found.length).toBe(1);
+      expect(fixture.componentInstance.previewData?.found[0].email).toBe('alice@shop.com');
+    });
+
+    it('onBulkFileSelected puts email not in cache into previewData.notFound', async () => {
+      fakeFileContent = 'unknown@example.com\n';
+      mockCtx.players.getAll.mockReturnValue([]);
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+
+      expect(fixture.componentInstance.previewData?.notFound).toContain('unknown@example.com');
+    });
+
+    it('onBulkFileSelected puts already-registered player into previewData.alreadyRegistered', async () => {
+      fakeFileContent = 'alice@shop.com\n';
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      // alice is already registered
+      eventPlayersSubject.next([{ ...epStub, playerId: alicePlayer.id }]);
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+
+      expect(fixture.componentInstance.previewData?.alreadyRegistered.length).toBe(1);
+      expect(fixture.componentInstance.previewData?.found.length).toBe(0);
+    });
+
+    it('preview panel is absent before file upload or Register Selected', async () => {
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const headings = Array.from(el.querySelectorAll('h3'));
+      expect(headings.some(h => h.textContent?.includes('Preview Registration'))).toBe(false);
+    });
+
+    it('preview panel shows after file upload', async () => {
+      fakeFileContent = 'alice@shop.com\n';
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const headings = Array.from(el.querySelectorAll('h3'));
+      expect(headings.some(h => h.textContent?.includes('Preview Registration'))).toBe(true);
+    });
+
+    it('cancelPreview hides the preview panel', async () => {
+      fakeFileContent = 'alice@shop.com\n';
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+      fixture.detectChanges();
+
+      fixture.componentInstance.cancelPreview();
+      fixture.detectChanges();
+
+      const el: HTMLElement = fixture.nativeElement;
+      const headings = Array.from(el.querySelectorAll('h3'));
+      expect(headings.some(h => h.textContent?.includes('Preview Registration'))).toBe(false);
+    });
+
+    it('confirmBulkRegistration calls apiService.bulkRegisterConfirm with correct payload', async () => {
+      fakeFileContent = 'alice@shop.com\n';
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      mockApiService.bulkRegisterConfirm.mockReturnValue(of({ registered: 1, created: 0, errors: [] }));
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+      fixture.detectChanges();
+
+      fixture.componentInstance.confirmBulkRegistration();
+
+      expect(mockApiService.bulkRegisterConfirm).toHaveBeenCalledWith(
+        EVENT_ID,
+        expect.objectContaining({
+          registrations: expect.arrayContaining([
+            expect.objectContaining({ playerId: alicePlayer.id, email: alicePlayer.email }),
+          ]),
+        }),
+      );
+    });
+
+    it('snackbar shows summary after successful confirmBulkRegistration', async () => {
+      fakeFileContent = 'alice@shop.com\n';
+      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
+      mockApiService.bulkRegisterConfirm.mockReturnValue(of({ registered: 2, created: 1, errors: [] } as BulkRegisterResultDto));
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const snackBarOpenSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open')
+        .mockReturnValue({} as any);
+
+      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
+      fixture.componentInstance.onBulkFileSelected(fakeEvent);
+      fixture.detectChanges();
+      fixture.componentInstance.confirmBulkRegistration();
+
+      expect(snackBarOpenSpy).toHaveBeenCalledWith(
+        expect.stringContaining('2 registered'),
+        'OK',
+        expect.any(Object),
+      );
+    });
+
+    it('onRegisterSelected builds preview from selectedPlayerIds without calling apiService', async () => {
+      mockCtx.players.getAll.mockReturnValue([alicePlayer, bobPlayer]);
+      mockCtx.players.getById.mockImplementation((id: number) =>
+        id === alicePlayer.id ? alicePlayer : id === bobPlayer.id ? bobPlayer : null,
+      );
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      currentEventSubject.next(regEvent);
+      fixture.detectChanges();
+
+      const comp = fixture.componentInstance;
+      comp.selectedPlayerIds.add(alicePlayer.id);
+      comp.onRegisterSelected();
+
+      expect(mockApiService.bulkRegisterConfirm).not.toHaveBeenCalled();
+      expect(comp.showPreview).toBe(true);
+      expect(comp.previewData?.found.length).toBe(1);
     });
   });
 });

--- a/tournament-client/src/app/features/events/event-detail.component.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.ts
@@ -14,11 +14,17 @@ import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/ma
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCardModule } from '@angular/material/card';
+import { MatListModule } from '@angular/material/list';
 import * as QRCode from 'qrcode';
 import { EventService } from '../../core/services/event.service';
 import { PlayerService } from '../../core/services/player.service';
 import { AuthService } from '../../core/services/auth.service';
-import { EventDto, RoundDto, StandingsEntry, EventPlayerDto, PlayerDto, POINT_SYSTEM_LABELS } from '../../core/models/api.models';
+import { ApiService } from '../../core/services/api.service';
+import { LocalStorageContext } from '../../core/services/local-storage-context.service';
+import {
+  EventDto, RoundDto, StandingsEntry, EventPlayerDto, PlayerDto, POINT_SYSTEM_LABELS,
+  BulkRegisterFoundDto, BulkRegisterPreviewDto,
+} from '../../core/models/api.models';
 import { PodCardComponent, PodResultState } from './pod-card.component';
 import { EventStandingsComponent } from './event-standings.component';
 
@@ -30,7 +36,7 @@ import { EventStandingsComponent } from './event-standings.component';
     MatTableModule, MatChipsModule, MatExpansionModule, MatIconModule,
     MatAutocompleteModule, MatSnackBarModule,
     PodCardComponent, EventStandingsComponent,
-    MatCheckboxModule, MatCardModule,
+    MatCheckboxModule, MatCardModule, MatListModule,
   ],
   template: `
     @if (event) {
@@ -162,6 +168,95 @@ import { EventStandingsComponent } from './event-standings.component';
                     </button>
                   </div>
                 }
+
+                <!-- ── Bulk Register ── -->
+                <div class="bulk-register-section">
+                  <h4>Bulk Register</h4>
+
+                  <!-- File upload -->
+                  <div class="bulk-upload-row">
+                    <button mat-stroked-button (click)="bulkFileInput.click()">
+                      <mat-icon>upload_file</mat-icon> Upload File
+                    </button>
+                    <input #bulkFileInput type="file" accept=".txt,.csv"
+                           style="display:none"
+                           (change)="onBulkFileSelected($event)">
+                  </div>
+
+                  <!-- Multi-select from store player pool -->
+                  <div class="bulk-multiselect">
+                    <div class="bulk-filter-row">
+                      <mat-form-field class="bulk-filter-field">
+                        <mat-label>Filter Players</mat-label>
+                        <input matInput [(ngModel)]="playerFilterText" (ngModelChange)="detect()">
+                      </mat-form-field>
+                      <button mat-button (click)="toggleSelectAll(true)">Select All</button>
+                      <button mat-button (click)="toggleSelectAll(false)">Deselect All</button>
+                    </div>
+                    <mat-selection-list>
+                      @for (p of filteredPlayerPool; track p.id) {
+                        <mat-list-option
+                          [selected]="selectedPlayerIds.has(p.id)"
+                          (selectedChange)="$event ? selectedPlayerIds.add(p.id) : selectedPlayerIds.delete(p.id); detect()">
+                          {{ p.name }} — {{ p.email }}
+                        </mat-list-option>
+                      }
+                    </mat-selection-list>
+                    <button mat-raised-button color="primary"
+                            [disabled]="selectedPlayerIds.size === 0"
+                            (click)="onRegisterSelected()">
+                      Register Selected
+                    </button>
+                  </div>
+
+                  <!-- Preview panel -->
+                  @if (showPreview && previewData) {
+                    <div class="bulk-preview-panel">
+                      <h3>Preview Registration</h3>
+
+                      @if (previewData.found.length > 0) {
+                        <p><strong>Will register ({{ previewData.found.length }}):</strong></p>
+                        @for (f of previewData.found; track f.playerId) {
+                          <div class="preview-row">
+                            <mat-checkbox [(ngModel)]="previewSelected[f.playerId]" (ngModelChange)="detect()">
+                              {{ f.name }} — {{ f.email }}
+                            </mat-checkbox>
+                          </div>
+                        }
+                      }
+
+                      @if (previewData.notFound.length > 0) {
+                        <p><strong>New players to create ({{ previewData.notFound.length }}):</strong></p>
+                        @for (email of previewData.notFound; track email) {
+                          <div class="preview-row">
+                            <mat-checkbox [(ngModel)]="unknownIncluded[email]" (ngModelChange)="detect()">
+                              {{ email }}
+                            </mat-checkbox>
+                            <mat-form-field class="name-field">
+                              <mat-label>Name for {{ email }}</mat-label>
+                              <input matInput [(ngModel)]="unknownNames[email]">
+                            </mat-form-field>
+                          </div>
+                        }
+                      }
+
+                      @if (previewData.alreadyRegistered.length > 0) {
+                        <p><strong>Already registered (skipped):</strong>
+                          @for (a of previewData.alreadyRegistered; track a.playerId) {
+                            <span> {{ a.email }}</span>
+                          }
+                        </p>
+                      }
+
+                      <div class="preview-actions">
+                        <button mat-raised-button color="primary" (click)="confirmBulkRegistration()">
+                          Confirm Registration
+                        </button>
+                        <button mat-button (click)="cancelPreview()">Cancel</button>
+                      </div>
+                    </div>
+                  }
+                </div>
               }
               @if (!authService.isStoreEmployee && authService.currentUser?.playerId && !isAlreadyRegistered(authService.currentUser!.playerId!) && !isEventFull) {
                 <div class="self-register-row">
@@ -471,6 +566,27 @@ export class EventDetailComponent implements OnInit {
   editingCommanderPlayerId: number | null = null;
   editCommanderValue = '';
 
+  // ── Bulk Register ─────────────────────────────────────────────────────────
+  storePlayerPool: PlayerDto[] = [];
+  selectedPlayerIds = new Set<number>();
+  playerFilterText = '';
+  showPreview = false;
+  previewData: BulkRegisterPreviewDto | null = null;
+  unknownNames: Record<string, string> = {};
+  unknownIncluded: Record<string, boolean> = {};
+  previewSelected: Record<number, boolean> = {};
+  private registeredPlayerIds = new Set<number>();
+
+  /** Called from template event handlers that need a detectChanges() call. */
+  detect(): void { this.cdr.detectChanges(); }
+
+  get filteredPlayerPool(): PlayerDto[] {
+    const search = this.playerFilterText.toLowerCase();
+    return this.storePlayerPool.filter(p =>
+      p.name.toLowerCase().includes(search) || p.email.toLowerCase().includes(search),
+    );
+  }
+
   constructor(
     private route: ActivatedRoute,
     private router: Router,
@@ -478,7 +594,9 @@ export class EventDetailComponent implements OnInit {
     private playerService: PlayerService,
     private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef,
-    public authService: AuthService
+    public authService: AuthService,
+    private apiService: ApiService,
+    private ctx: LocalStorageContext,
   ) {}
 
   ngOnInit() {
@@ -500,7 +618,11 @@ export class EventDetailComponent implements OnInit {
       }
       this.cdr.detectChanges();
     });
-    this.eventService.eventPlayers$.subscribe(p => { this.eventPlayers = p; this.cdr.detectChanges(); });
+    this.eventService.eventPlayers$.subscribe(p => {
+      this.eventPlayers = p;
+      this.registeredPlayerIds = new Set(p.map(ep => ep.playerId));
+      this.cdr.detectChanges();
+    });
     this.playerService.players$.subscribe(p => { this.allPlayers = p; this.cdr.detectChanges(); });
     this.eventService.rounds$.subscribe(r => {
       this.rounds = r;
@@ -516,6 +638,7 @@ export class EventDetailComponent implements OnInit {
     this.eventService.loadRounds(this.eventId);
     this.playerService.loadAllPlayers();
     this.loadStandings();
+    this.storePlayerPool = this.ctx.players.getAll();
   }
 
   private syncPodStates(rounds: RoundDto[]) {
@@ -919,5 +1042,107 @@ export class EventDetailComponent implements OnInit {
     if (event.index === this.PLAYERS_TAB) {
       this.eventService.loadEventPlayers(this.eventId);
     }
+  }
+
+  // ── Bulk Register methods ─────────────────────────────────────────────────
+
+  onBulkFileSelected(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const lines = (reader.result as string)
+        .split('\n')
+        .map(l => l.trim().toLowerCase())
+        .filter(l => l.length > 0 && l !== 'email');
+
+      const allPlayers = this.ctx.players.getAll();
+      const found: BulkRegisterFoundDto[] = [];
+      const notFound: string[] = [];
+      const alreadyRegistered: BulkRegisterFoundDto[] = [];
+
+      for (const email of lines) {
+        const player = allPlayers.find(p => p.email.toLowerCase() === email);
+        if (!player) {
+          notFound.push(email);
+        } else if (this.registeredPlayerIds.has(player.id)) {
+          alreadyRegistered.push({ playerId: player.id, name: player.name, email: player.email });
+        } else {
+          found.push({ playerId: player.id, name: player.name, email: player.email });
+        }
+      }
+
+      this.previewData = { found, notFound, alreadyRegistered };
+      this.previewSelected = Object.fromEntries(found.map(f => [f.playerId, true]));
+      this.unknownNames    = Object.fromEntries(notFound.map(e => [e, '']));
+      this.unknownIncluded = Object.fromEntries(notFound.map(e => [e, true]));
+      this.showPreview = true;
+      this.cdr.detectChanges();
+    };
+    reader.readAsText(file);
+  }
+
+  onRegisterSelected(): void {
+    const found: BulkRegisterFoundDto[] = [];
+    const alreadyRegistered: BulkRegisterFoundDto[] = [];
+    for (const id of this.selectedPlayerIds) {
+      const player = this.ctx.players.getById(id);
+      if (!player) continue;
+      if (this.registeredPlayerIds.has(id)) {
+        alreadyRegistered.push({ playerId: id, name: player.name, email: player.email });
+      } else {
+        found.push({ playerId: id, name: player.name, email: player.email });
+      }
+    }
+    this.previewData = { found, notFound: [], alreadyRegistered };
+    this.previewSelected = Object.fromEntries(found.map(f => [f.playerId, true]));
+    this.showPreview = true;
+    this.cdr.detectChanges();
+  }
+
+  confirmBulkRegistration(): void {
+    if (!this.previewData) return;
+    const registrations = [
+      // Found players whose checkbox is still checked
+      ...this.previewData.found
+        .filter(f => this.previewSelected[f.playerId])
+        .map(f => ({ playerId: f.playerId, email: f.email })),
+      // Unknown emails that the user has included and filled in a name for
+      ...this.previewData.notFound
+        .filter(e => this.unknownIncluded[e])
+        .map(e => ({ playerId: null, email: e, name: this.unknownNames[e] || null })),
+    ];
+
+    this.apiService.bulkRegisterConfirm(this.eventId, { registrations }).subscribe({
+      next: (result) => {
+        const msg = `${result.registered} registered, ${result.created} new players created`;
+        this.snackBar.open(msg, 'OK', { duration: 5000 });
+        this.showPreview = false;
+        this.previewData = null;
+        this.selectedPlayerIds.clear();
+        this.eventService.loadEventPlayers(this.eventId);
+        this.eventService.loadEvent(this.eventId);
+        this.cdr.detectChanges();
+      },
+      error: (err) => {
+        this.snackBar.open(err.error?.error || 'Bulk registration failed', 'OK', { duration: 4000 });
+        this.cdr.detectChanges();
+      },
+    });
+  }
+
+  cancelPreview(): void {
+    this.showPreview = false;
+    this.previewData = null;
+    this.cdr.detectChanges();
+  }
+
+  toggleSelectAll(selectAll: boolean): void {
+    if (selectAll) {
+      this.filteredPlayerPool.forEach(p => this.selectedPlayerIds.add(p.id));
+    } else {
+      this.selectedPlayerIds.clear();
+    }
+    this.cdr.detectChanges();
   }
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/events/{id}/bulkregister/confirm` endpoint that registers a list of players, creating new player records for unknown emails and returning a result with counts and per-email errors
- Frontend adds three registration paths to the Event Detail page: CSV/TXT file upload, multi-select checkbox list with text filter, and Select All/Deselect All — all feed into a preview panel before confirming
- Full TDD: 5 backend xUnit tests, 12 frontend Jest tests, 7 Playwright E2E test blocks; role-gating enforced throughout

## Test plan
- [x] 5 backend xUnit tests pass (`EventBulkRegisterTests`)
- [x] All 104 frontend Jest tests for `event-detail.component.spec.ts` pass
- [x] All 43 E2E tests for `event-detail.spec.ts` pass
- [x] `/check-zone` clean on `event-detail.component.ts`
- [x] `/build` — 0 errors
- [x] 14 pre-existing `event.service.spec.ts` failures confirmed on `dev` branch (not introduced by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)