### PR TITLE
fix: clear stale event players when navigating to a new event

### DIFF
--- a/tournament-client/src/app/core/services/event.service.spec.ts
+++ b/tournament-client/src/app/core/services/event.service.spec.ts
@@ -452,4 +452,54 @@ describe('EventService', () => {
       expect(await firstValueFrom(service.rounds$)).toEqual([]);
     });
   });
+
+  // ── loadEventPlayers ──────────────────────────────────────────────────────
+
+  describe('loadEventPlayers', () => {
+    const player1: EventPlayerDto = {
+      playerId: 1, playerName: 'Alice', isCheckedIn: false,
+      isDropped: false, isDisqualified: false, isWaitlisted: false,
+      checkInToken: null, podColor: null, seatNumber: null,
+    };
+
+    it('clears stale players when loading a different event with no cache', async () => {
+      // Seed subject with players from a previous event
+      mockApi.getEventPlayers.mockReturnValueOnce(of([player1]));
+      service.loadEventPlayers(1);
+      expect(await firstValueFrom(service.eventPlayers$)).toEqual([player1]);
+
+      // Now load a new event — no cache, API not yet resolved
+      mockApi.getEventPlayers.mockReturnValue(new (require('rxjs').Subject)());
+      service.loadEventPlayers(2);
+
+      // Should immediately show empty list, not event 1's players
+      expect(await firstValueFrom(service.eventPlayers$)).toEqual([]);
+    });
+
+    it('emits cached players immediately when cache exists for the event', async () => {
+      // Use a pending Subject so the API never synchronously overwrites the cache.
+      mockApi.getEventPlayers.mockReturnValue(new (require('rxjs').Subject)());
+      const cacheKey = 'to_store_1_ep_5';
+      mockStorage.getItem.mockImplementation((k: string) =>
+        k === cacheKey ? JSON.stringify([player1]) : null
+      );
+
+      service.loadEventPlayers(5);
+
+      expect(await firstValueFrom(service.eventPlayers$)).toEqual([player1]);
+    });
+
+    it('replaces cached players with fresh API response', async () => {
+      const player2: EventPlayerDto = {
+        playerId: 2, playerName: 'Bob', isCheckedIn: false,
+        isDropped: false, isDisqualified: false, isWaitlisted: false,
+        checkInToken: null, podColor: null, seatNumber: null,
+      };
+      mockApi.getEventPlayers.mockReturnValue(of([player2]));
+
+      service.loadEventPlayers(5);
+
+      expect(await firstValueFrom(service.eventPlayers$)).toEqual([player2]);
+    });
+  });
 });

--- a/tournament-client/src/app/core/services/event.service.ts
+++ b/tournament-client/src/app/core/services/event.service.ts
@@ -246,7 +246,8 @@ export class EventService {
 
   loadEventPlayers(eventId: number): void {
     const cached = this.readCache<EventPlayerDto>('ep', eventId);
-    if (cached.length > 0) this.eventPlayersSubject.next(cached);
+    // Always emit immediately (cached data or []) to clear any stale players from a previous event.
+    this.eventPlayersSubject.next(cached);
     if (eventId < 0) return; // locally-created event — no server record exists
 
     this.api.getEventPlayers(eventId).pipe(


### PR DESCRIPTION
## Summary
- `loadEventPlayers()` always emits the per-event cache (or `[]` if no cache) before the API call, so switching events immediately clears the previous event's player list from `eventPlayersSubject`
- Previously, navigating to a new event with no cache left the old event's players visible in the UI until the API responded

## Root cause
`BehaviorSubject` retains its last emitted value. `loadEventPlayers` only emitted cached data if the cache was non-empty — meaning a new/uncached event never cleared the stale data before the API resolved.

## Test plan
- [x] 3 new unit tests in `event.service.spec.ts`: clears stale players, emits cache immediately, replaces with API response — all pass
- [x] Pre-existing 14 failures in `event.service.spec.ts` are unchanged (missing `storeContext` mock — pre-existing on `dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)