### PR TITLE
feat: add sync button to offline event cards

### DIFF
--- a/tournament-client/e2e/events/event-list.spec.ts
+++ b/tournament-client/e2e/events/event-list.spec.ts
@@ -310,6 +310,104 @@ test.describe('Event List — role-based UI: Admin, no store selected', () => {
   });
 });
 
+// ── Sync button on offline event cards ────────────────────────────────────────
+
+const OFFLINE_EVENT = makeEventDto({ id: -1, name: 'Offline Event', status: 'Registration' });
+const SYNCED_EVENT  = makeEventDto({ id: 99, name: 'Synced Event',  status: 'Registration' });
+
+test.describe('Event List — sync button visibility', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: 1 });
+    // Seed an offline (negative-ID) event into localStorage before Angular boots.
+    await page.addInitScript((evt) => {
+      localStorage.setItem('to_store_1_events', JSON.stringify([evt]));
+      localStorage.setItem('to_store_1_events_meta', JSON.stringify([[-1, 'added']]));
+    }, OFFLINE_EVENT);
+    await stubUnmatchedApi(page);
+    await page.route('**/api/events', route => route.fulfill({ status: 500 }));
+    await page.goto('/events');
+  });
+
+  test('Sync button is visible on an offline event card', async ({ page }) => {
+    const card = page.locator('mat-card.event-card').filter({ hasText: 'Offline Event' });
+    await expect(card.locator('button.sync-btn')).toBeVisible();
+  });
+
+  test('Sync button icon shows sync icon', async ({ page }) => {
+    const card = page.locator('mat-card.event-card').filter({ hasText: 'Offline Event' });
+    await expect(card.locator('button.sync-btn mat-icon')).toHaveText('sync');
+  });
+});
+
+test.describe('Event List — sync button NOT visible on synced event', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: 1 });
+    await stubUnmatchedApi(page);
+    await mockGetEvents(page, [SYNCED_EVENT]);
+    await page.goto('/events');
+  });
+
+  test('Sync button is NOT visible on a synced event card', async ({ page }) => {
+    const card = page.locator('mat-card.event-card').filter({ hasText: 'Synced Event' });
+    await expect(card.locator('button.sync-btn')).not.toBeVisible();
+  });
+});
+
+test.describe('Event List — sync button click', () => {
+  test('clicking Sync calls POST /api/events and shows success snackbar', async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: 1 });
+    const CREATED_EVENT = makeEventDto({ id: 5, name: 'Offline Event', status: 'Registration' });
+    await page.addInitScript((evt) => {
+      localStorage.setItem('to_store_1_events', JSON.stringify([evt]));
+      localStorage.setItem('to_store_1_events_meta', JSON.stringify([[-1, 'added']]));
+    }, OFFLINE_EVENT);
+    await stubUnmatchedApi(page);
+    // loadAllEvents early-exits from cache; let POST /api/events succeed with a real ID
+    await page.route('**/api/events', route => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({ json: CREATED_EVENT });
+      } else {
+        route.fulfill({ status: 500 });
+      }
+    });
+    await page.goto('/events');
+
+    const card = page.locator('mat-card.event-card').filter({ hasText: 'Offline Event' });
+    await card.locator('button.sync-btn').click();
+
+    await expect(page.getByText(/synced successfully/i)).toBeVisible();
+  });
+
+  test('clicking Sync does NOT navigate away from the event list', async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: 1 });
+    await page.addInitScript((evt) => {
+      localStorage.setItem('to_store_1_events', JSON.stringify([evt]));
+      localStorage.setItem('to_store_1_events_meta', JSON.stringify([[-1, 'added']]));
+    }, OFFLINE_EVENT);
+    await stubUnmatchedApi(page);
+    await page.route('**/api/events', route => route.fulfill({ status: 500 }));
+    await page.goto('/events');
+
+    const card = page.locator('mat-card.event-card').filter({ hasText: 'Offline Event' });
+    await card.locator('button.sync-btn').click();
+
+    await expect(page).toHaveURL(/\/events$/);
+  });
+
+  test('Player does NOT see a Sync button even for an offline event', async ({ page }) => {
+    await loginAs(page, 'Player');
+    await page.addInitScript((evt) => {
+      localStorage.setItem('to_store_1_events', JSON.stringify([evt]));
+      localStorage.setItem('to_store_1_events_meta', JSON.stringify([[-1, 'added']]));
+    }, OFFLINE_EVENT);
+    await stubUnmatchedApi(page);
+    await page.route('**/api/events', route => route.fulfill({ status: 500 }));
+    await page.goto('/events');
+
+    await expect(page.locator('button.sync-btn')).not.toBeVisible();
+  });
+});
+
 // ── Role-based UI: Admin — store selected via toolbar ─────────────────────────
 
 test.describe('Event List — role-based UI: Admin, store selected via toolbar', () => {

--- a/tournament-client/src/app/features/events/event-list.component.spec.ts
+++ b/tournament-client/src/app/features/events/event-list.component.spec.ts
@@ -7,6 +7,7 @@ import { EventListComponent } from './event-list.component';
 import { EventService } from '../../core/services/event.service';
 import { AuthService } from '../../core/services/auth.service';
 import { StoreContextService } from '../../core/services/store-context.service';
+import { SyncService } from '../../core/services/sync.service';
 import { EventDto } from '../../core/models/api.models';
 
 describe('EventListComponent (smoke)', () => {
@@ -136,5 +137,82 @@ describe('EventListComponent — Create New Event visibility (Admin)', () => {
     const fixture = TestBed.createComponent(EventListComponent);
     fixture.detectChanges();
     expect(fixture.nativeElement.textContent).not.toContain('Create New Event');
+  });
+});
+
+// ── Sync button on event cards ─────────────────────────────────────────────────
+
+describe('EventListComponent — sync button', () => {
+  const eventsSubject = new BehaviorSubject<EventDto[]>([]);
+  const selectedStoreId$ = new Subject<number | null>();
+
+  const SYNCED_EVENT:  EventDto = { id: 1,  name: 'Synced Event',  date: '2026-03-15', status: 'Registration', playerCount: 0, defaultRoundTimeMinutes: 55, maxPlayers: null, pointSystem: 'ScoreBased' };
+  const OFFLINE_EVENT: EventDto = { id: -1, name: 'Offline Event', date: '2026-03-15', status: 'Registration', playerCount: 0, defaultRoundTimeMinutes: 55, maxPlayers: null, pointSystem: 'ScoreBased' };
+
+  let mockSyncService: { push: jest.Mock };
+  let mockEventService: Partial<EventService>;
+  let snackBarOpenSpy: jest.SpyInstance;
+
+  async function setup(events: EventDto[]) {
+    eventsSubject.next(events);
+    mockSyncService = { push: jest.fn().mockResolvedValue({ pushed: 1, conflicts: 0, errors: 0 }) };
+    mockEventService = {
+      events$: eventsSubject.asObservable(),
+      loadAllEvents: jest.fn(),
+      createEvent: jest.fn().mockReturnValue(of(null)),
+      removeEvent: jest.fn().mockReturnValue(of(null)),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [EventListComponent],
+      providers: [
+        provideRouter([]),
+        provideAnimationsAsync(),
+        { provide: EventService,        useValue: mockEventService },
+        { provide: MatSnackBar,         useValue: { open: jest.fn() } },
+        { provide: AuthService,         useValue: { isStoreEmployee: true, isAdmin: false, currentUser: null } },
+        { provide: StoreContextService, useValue: { selectedStoreId: 1, selectedStoreId$: selectedStoreId$.asObservable() } },
+        { provide: SyncService,         useValue: mockSyncService },
+      ],
+    }).compileComponents();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  it('shows a Sync button on an offline (negative-ID) event card', async () => {
+    await setup([OFFLINE_EVENT]);
+    const fixture = TestBed.createComponent(EventListComponent);
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('button.sync-btn');
+    expect(btn).toBeTruthy();
+  });
+
+  it('does NOT show a Sync button on a synced (positive-ID) event card', async () => {
+    await setup([SYNCED_EVENT]);
+    const fixture = TestBed.createComponent(EventListComponent);
+    fixture.detectChanges();
+    const btn = fixture.nativeElement.querySelector('button.sync-btn');
+    expect(btn).toBeNull();
+  });
+
+  it('clicking Sync calls SyncService.push()', async () => {
+    await setup([OFFLINE_EVENT]);
+    const fixture = TestBed.createComponent(EventListComponent);
+    fixture.detectChanges();
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('button.sync-btn');
+    btn.click();
+    expect(mockSyncService.push).toHaveBeenCalled();
+  });
+
+  it('clicking Sync does NOT navigate to the event (stopPropagation)', async () => {
+    await setup([OFFLINE_EVENT]);
+    const fixture = TestBed.createComponent(EventListComponent);
+    fixture.detectChanges();
+    const card: HTMLElement = fixture.nativeElement.querySelector('mat-card.event-card');
+    const btn: HTMLButtonElement = fixture.nativeElement.querySelector('button.sync-btn');
+    const cardClickSpy = jest.fn();
+    card.addEventListener('click', cardClickSpy);
+    btn.click();
+    expect(cardClickSpy).not.toHaveBeenCalled();
   });
 });

--- a/tournament-client/src/app/features/events/event-list.component.ts
+++ b/tournament-client/src/app/features/events/event-list.component.ts
@@ -17,6 +17,7 @@ import { Subscription } from 'rxjs';
 import { EventService } from '../../core/services/event.service';
 import { AuthService } from '../../core/services/auth.service';
 import { StoreContextService } from '../../core/services/store-context.service';
+import { SyncService } from '../../core/services/sync.service';
 import { EventDto, PointSystem, POINT_SYSTEM_LABELS } from '../../core/models/api.models';
 
 @Component({
@@ -99,6 +100,11 @@ import { EventDto, PointSystem, POINT_SYSTEM_LABELS } from '../../core/models/ap
                 </mat-card-content>
                 @if (authService.isStoreEmployee) {
                   <mat-card-actions>
+                    @if (isOffline(evt)) {
+                      <button mat-button color="accent" class="sync-btn" (click)="syncEvent(evt, $event)">
+                        <mat-icon>sync</mat-icon> Sync
+                      </button>
+                    }
                     <button mat-button color="warn" (click)="removeEvent(evt.id, $event)">
                       <mat-icon>delete</mat-icon> Remove
                     </button>
@@ -164,7 +170,8 @@ export class EventListComponent implements OnInit, OnDestroy {
     private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef,
     public authService: AuthService,
-    public storeContext: StoreContextService
+    public storeContext: StoreContextService,
+    private syncService: SyncService
   ) {}
 
   ngOnInit() {
@@ -181,6 +188,26 @@ export class EventListComponent implements OnInit, OnDestroy {
 
   ngOnDestroy(): void {
     this.storeChangeSub.unsubscribe();
+  }
+
+  isOffline(evt: EventDto): boolean {
+    return evt.id < 0;
+  }
+
+  syncEvent(evt: EventDto, event: MouseEvent) {
+    event.stopPropagation();
+    this.syncService.push().then(result => {
+      if (result.errors > 0) {
+        this.snackBar.open('Sync completed with errors', 'OK', { duration: 4000 });
+      } else {
+        this.snackBar.open('Event synced successfully', 'OK', { duration: 3000 });
+      }
+      this.eventService.loadAllEvents();
+      this.cdr.detectChanges();
+    }).catch(() => {
+      this.snackBar.open('Sync failed', 'OK', { duration: 4000 });
+      this.cdr.detectChanges();
+    });
   }
 
   removeEvent(id: number, event: MouseEvent) {


### PR DESCRIPTION
## Summary
- Adds a **Sync** button to event cards that were created offline (negative ID) — visible only to store employees
- Button is hidden on normally-synced events (positive ID)
- Clicking Sync calls \`SyncService.push()\`, shows a success or error snackbar, and reloads the event list
- Click propagation is stopped so the card navigation is not triggered

## Test plan
- [x] 4 Jest unit tests: sync button visible for offline event, hidden for synced event, click calls \`SyncService.push()\`, click stops propagation — all pass
- [x] 6 Playwright E2E tests: visibility, icon, hidden on synced, click success snackbar, no navigation, player role gate — all pass (35/35 event-list spec)
- [x] \`/check-zone\` clean on \`event-list.component.ts\`
- [x] Angular build: 0 errors (2 pre-existing warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)