### PR TITLE
feat: move bulk register into MatDialog with capacity guard

### DIFF
--- a/tournament-client/e2e/events/event-detail.spec.ts
+++ b/tournament-client/e2e/events/event-detail.spec.ts
@@ -687,3 +687,72 @@ test.describe('Bulk Register: role gate', () => {
     await expect(page.getByRole('button', { name: 'Select All', exact: true })).not.toBeVisible();
   });
 });
+
+// ── Bulk Register: capacity guard ─────────────────────────────────────────────
+
+test.describe('Bulk Register: capacity guard — over capacity', () => {
+  // Event has maxPlayers: 3, playerCount: 2 → only 1 slot left
+  // Two players are in the store pool but not yet registered → selecting both exceeds capacity
+  const CAPPED_EVENT = makeEventDto({ id: EVENT_ID, status: 'Registration', playerCount: 2, maxPlayers: 3, storeId: STORE_ID });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, CAPPED_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER, BOB_STORE_PLAYER]);
+    await page.goto(`/events/${EVENT_ID}`);
+  });
+
+  test('capacity warning is shown when selection exceeds available slots', async ({ page }) => {
+    // Select both players (2 > 1 available slot)
+    await page.getByRole('button', { name: 'Select All', exact: true }).click();
+    await page.getByRole('button', { name: /Register Selected/i }).click();
+
+    await expect(page.locator('.capacity-warning')).toBeVisible();
+    await expect(page.locator('.capacity-warning')).toContainText('1 remaining');
+  });
+
+  test('Confirm Registration button is disabled when over capacity', async ({ page }) => {
+    await page.getByRole('button', { name: 'Select All', exact: true }).click();
+    await page.getByRole('button', { name: /Register Selected/i }).click();
+
+    await expect(page.getByRole('button', { name: /Confirm Registration/i })).toBeDisabled();
+  });
+
+  test('warning disappears and Confirm is enabled after deselecting to fit capacity', async ({ page }) => {
+    await page.getByRole('button', { name: 'Select All', exact: true }).click();
+    await page.getByRole('button', { name: /Register Selected/i }).click();
+
+    // Uncheck one player to bring count within the 1 available slot
+    const checkboxes = page.locator('.bulk-preview-panel mat-checkbox');
+    await checkboxes.first().click();
+
+    await expect(page.locator('.capacity-warning')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /Confirm Registration/i })).toBeEnabled();
+  });
+});
+
+test.describe('Bulk Register: capacity guard — within capacity', () => {
+  // Event has no maxPlayers → unlimited
+  const UNLIMITED_EVENT = makeEventDto({ id: EVENT_ID, status: 'Registration', playerCount: 2, maxPlayers: null, storeId: STORE_ID });
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID });
+    await stubUnmatchedApi(page);
+    await mockGetStores(page, []);
+    await mockGetEvent(page, UNLIMITED_EVENT);
+    await mockGetEventPlayers(page, EVENT_ID, []);
+    await seedStorePlayers(page, [ALICE_STORE_PLAYER, BOB_STORE_PLAYER]);
+    await page.goto(`/events/${EVENT_ID}`);
+  });
+
+  test('no capacity warning when event has no maxPlayers', async ({ page }) => {
+    await page.getByRole('button', { name: 'Select All', exact: true }).click();
+    await page.getByRole('button', { name: /Register Selected/i }).click();
+
+    await expect(page.locator('.capacity-warning')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: /Confirm Registration/i })).toBeEnabled();
+  });
+});

--- a/tournament-client/src/app/features/events/dialogs/bulk-register-dialog.component.spec.ts
+++ b/tournament-client/src/app/features/events/dialogs/bulk-register-dialog.component.spec.ts
@@ -1,0 +1,202 @@
+import { TestBed } from '@angular/core/testing';
+import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
+import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
+import { of } from 'rxjs';
+import { BulkRegisterDialogComponent, BulkRegisterDialogData } from './bulk-register-dialog.component';
+import { ApiService } from '../../../core/services/api.service';
+import { LocalStorageContext } from '../../../core/services/local-storage-context.service';
+import { BulkRegisterResultDto, PlayerDto } from '../../../core/models/api.models';
+
+describe('BulkRegisterDialogComponent', () => {
+  const alicePlayer: PlayerDto = {
+    id: 10, name: 'Alice', email: 'alice@shop.com',
+    mu: 25, sigma: 8.333, conservativeScore: 0,
+    isRanked: false, placementGamesLeft: 5, isActive: true,
+  };
+  const bobPlayer: PlayerDto = {
+    id: 11, name: 'Bob', email: 'bob@shop.com',
+    mu: 25, sigma: 8.333, conservativeScore: 0,
+    isRanked: false, placementGamesLeft: 5, isActive: true,
+  };
+
+  const dialogData: BulkRegisterDialogData = {
+    eventId: 7,
+    availableSlots: 4,
+    registeredPlayerIds: new Set<number>(),
+  };
+
+  let mockApiService: { bulkRegisterConfirm: jest.Mock };
+  let mockCtx: { players: { getAll: jest.Mock; getById: jest.Mock } };
+  let mockDialogRef: { close: jest.Mock };
+
+  function setup(data: BulkRegisterDialogData = dialogData) {
+    mockApiService = { bulkRegisterConfirm: jest.fn().mockReturnValue(of({ registered: 1, created: 0, errors: [] } as BulkRegisterResultDto)) };
+    mockCtx = {
+      players: {
+        getAll:  jest.fn().mockReturnValue([alicePlayer, bobPlayer]),
+        getById: jest.fn().mockImplementation((id: number) =>
+          id === alicePlayer.id ? alicePlayer : id === bobPlayer.id ? bobPlayer : null),
+      },
+    };
+    mockDialogRef = { close: jest.fn() };
+
+    return TestBed.configureTestingModule({
+      imports: [BulkRegisterDialogComponent],
+      providers: [
+        provideAnimationsAsync(),
+        { provide: MAT_DIALOG_DATA, useValue: data },
+        { provide: MatDialogRef,    useValue: mockDialogRef },
+        { provide: ApiService,      useValue: mockApiService },
+        { provide: LocalStorageContext, useValue: mockCtx },
+      ],
+    }).compileComponents();
+  }
+
+  afterEach(() => TestBed.resetTestingModule());
+
+  // ── Rendering ──────────────────────────────────────────────────────────────
+
+  it('should create', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('shows the dialog title', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Bulk Register Players');
+  });
+
+  it('renders store players in the selection list', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Alice');
+    expect(fixture.nativeElement.textContent).toContain('Bob');
+  });
+
+  // ── Select / Deselect All ──────────────────────────────────────────────────
+
+  it('Select All adds all pool players to selectedPlayerIds', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.toggleSelectAll(true);
+    expect(comp.selectedPlayerIds.size).toBe(2);
+  });
+
+  it('Deselect All clears selectedPlayerIds', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.toggleSelectAll(true);
+    comp.toggleSelectAll(false);
+    expect(comp.selectedPlayerIds.size).toBe(0);
+  });
+
+  // ── Register Selected → preview ────────────────────────────────────────────
+
+  it('onRegisterSelected builds previewData and shows preview panel', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.selectedPlayerIds.add(alicePlayer.id);
+    comp.onRegisterSelected();
+    expect(comp.showPreview).toBe(true);
+    expect(comp.previewData?.found.length).toBe(1);
+    expect(comp.previewData?.found[0].email).toBe(alicePlayer.email);
+  });
+
+  it('already-registered players go into previewData.alreadyRegistered', async () => {
+    const dataWithAliceRegistered: BulkRegisterDialogData = {
+      ...dialogData,
+      registeredPlayerIds: new Set([alicePlayer.id]),
+    };
+    await setup(dataWithAliceRegistered);
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.selectedPlayerIds.add(alicePlayer.id);
+    comp.onRegisterSelected();
+    expect(comp.previewData?.alreadyRegistered.length).toBe(1);
+    expect(comp.previewData?.found.length).toBe(0);
+  });
+
+  // ── Capacity guard ─────────────────────────────────────────────────────────
+
+  it('previewOverCapacity is true when selection exceeds availableSlots', async () => {
+    const tightData: BulkRegisterDialogData = { ...dialogData, availableSlots: 1 };
+    await setup(tightData);
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.selectedPlayerIds.add(alicePlayer.id);
+    comp.selectedPlayerIds.add(bobPlayer.id);
+    comp.onRegisterSelected();
+    expect(comp.previewOverCapacity).toBe(true);
+  });
+
+  it('confirmBulkRegistration is blocked when previewOverCapacity', async () => {
+    const tightData: BulkRegisterDialogData = { ...dialogData, availableSlots: 1 };
+    await setup(tightData);
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.selectedPlayerIds.add(alicePlayer.id);
+    comp.selectedPlayerIds.add(bobPlayer.id);
+    comp.onRegisterSelected();
+    comp.confirm();
+    expect(mockApiService.bulkRegisterConfirm).not.toHaveBeenCalled();
+  });
+
+  // ── Confirm ────────────────────────────────────────────────────────────────
+
+  it('confirm calls bulkRegisterConfirm and closes the dialog with the result', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.selectedPlayerIds.add(alicePlayer.id);
+    comp.onRegisterSelected();
+    comp.confirm();
+    expect(mockApiService.bulkRegisterConfirm).toHaveBeenCalledWith(
+      dialogData.eventId,
+      expect.objectContaining({
+        registrations: expect.arrayContaining([
+          expect.objectContaining({ playerId: alicePlayer.id }),
+        ]),
+      }),
+    );
+    expect(mockDialogRef.close).toHaveBeenCalledWith(
+      expect.objectContaining({ registered: 1 }),
+    );
+  });
+
+  // ── Cancel ─────────────────────────────────────────────────────────────────
+
+  it('cancel closes the dialog without a result', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    fixture.componentInstance.cancel();
+    expect(mockDialogRef.close).toHaveBeenCalledWith(undefined);
+  });
+
+  it('cancelPreview hides the preview panel', async () => {
+    await setup();
+    const fixture = TestBed.createComponent(BulkRegisterDialogComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    comp.selectedPlayerIds.add(alicePlayer.id);
+    comp.onRegisterSelected();
+    expect(comp.showPreview).toBe(true);
+    comp.cancelPreview();
+    expect(comp.showPreview).toBe(false);
+  });
+});

--- a/tournament-client/src/app/features/events/dialogs/bulk-register-dialog.component.ts
+++ b/tournament-client/src/app/features/events/dialogs/bulk-register-dialog.component.ts
@@ -1,0 +1,278 @@
+import { Component, Inject, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatCheckboxModule } from '@angular/material/checkbox';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { LocalStorageContext } from '../../../core/services/local-storage-context.service';
+import { ApiService } from '../../../core/services/api.service';
+import {
+  BulkRegisterConfirmDto,
+  BulkRegisterFoundDto,
+  BulkRegisterPreviewDto,
+  BulkRegisterResultDto,
+  PlayerDto,
+} from '../../../core/models/api.models';
+
+export interface BulkRegisterDialogData {
+  eventId: number;
+  availableSlots: number;
+  registeredPlayerIds: Set<number>;
+}
+
+@Component({
+  selector: 'app-bulk-register-dialog',
+  imports: [
+    CommonModule, FormsModule,
+    MatButtonModule, MatCheckboxModule, MatDialogModule,
+    MatFormFieldModule, MatIconModule, MatInputModule, MatListModule,
+  ],
+  template: `
+    <h2 mat-dialog-title>Bulk Register Players</h2>
+
+    <mat-dialog-content>
+      @if (!showPreview) {
+        <!-- File upload -->
+        <div class="bulk-upload-row">
+          <button mat-stroked-button (click)="fileInput.click()">
+            <mat-icon>upload_file</mat-icon> Upload File
+          </button>
+          <input #fileInput type="file" accept=".txt,.csv"
+                 style="display:none"
+                 (change)="onFileSelected($event)">
+          <span class="upload-hint">CSV or TXT — one email per line</span>
+        </div>
+
+        <!-- Multi-select -->
+        <div class="bulk-multiselect">
+          <div class="bulk-filter-row">
+            <mat-form-field class="bulk-filter-field">
+              <mat-label>Filter Players</mat-label>
+              <input matInput [(ngModel)]="playerFilterText" (ngModelChange)="cdr.detectChanges()">
+            </mat-form-field>
+            <button mat-button (click)="toggleSelectAll(true)">Select All</button>
+            <button mat-button (click)="toggleSelectAll(false)">Deselect All</button>
+          </div>
+          <mat-selection-list>
+            @for (p of filteredPool; track p.id) {
+              <mat-list-option
+                [selected]="selectedPlayerIds.has(p.id)"
+                (selectedChange)="$event ? selectedPlayerIds.add(p.id) : selectedPlayerIds.delete(p.id); cdr.detectChanges()">
+                {{ p.name }} — {{ p.email }}
+              </mat-list-option>
+            }
+          </mat-selection-list>
+        </div>
+      }
+
+      @if (showPreview && previewData) {
+        <div class="bulk-preview-panel">
+          <h3>Preview Registration</h3>
+
+          @if (previewData.found.length > 0) {
+            <p><strong>Will register ({{ previewData.found.length }}):</strong></p>
+            @for (f of previewData.found; track f.playerId) {
+              <div class="preview-row">
+                <mat-checkbox [(ngModel)]="previewSelected[f.playerId]" (ngModelChange)="cdr.detectChanges()">
+                  {{ f.name }} — {{ f.email }}
+                </mat-checkbox>
+              </div>
+            }
+          }
+
+          @if (previewData.notFound.length > 0) {
+            <p><strong>New players to create ({{ previewData.notFound.length }}):</strong></p>
+            @for (email of previewData.notFound; track email) {
+              <div class="preview-row">
+                <mat-checkbox [(ngModel)]="unknownIncluded[email]" (ngModelChange)="cdr.detectChanges()">
+                  {{ email }}
+                </mat-checkbox>
+                <mat-form-field class="name-field">
+                  <mat-label>Name for {{ email }}</mat-label>
+                  <input matInput [(ngModel)]="unknownNames[email]">
+                </mat-form-field>
+              </div>
+            }
+          }
+
+          @if (previewData.alreadyRegistered.length > 0) {
+            <p><strong>Already registered (skipped):</strong>
+              @for (a of previewData.alreadyRegistered; track a.playerId) {
+                <span> {{ a.email }}</span>
+              }
+            </p>
+          }
+
+          @if (previewOverCapacity) {
+            <p class="capacity-warning">
+              <mat-icon>warning</mat-icon>
+              Selection exceeds available slots ({{ data.availableSlots }} remaining). Deselect some players to continue.
+            </p>
+          }
+        </div>
+      }
+    </mat-dialog-content>
+
+    <mat-dialog-actions align="end">
+      @if (!showPreview) {
+        <button mat-button (click)="cancel()">Cancel</button>
+        <button mat-raised-button color="primary"
+                [disabled]="selectedPlayerIds.size === 0"
+                (click)="onRegisterSelected()">
+          Preview Registration
+        </button>
+      } @else {
+        <button mat-button (click)="cancelPreview()">Back</button>
+        <button mat-raised-button color="primary"
+                [disabled]="previewOverCapacity"
+                (click)="confirm()">
+          Confirm Registration
+        </button>
+      }
+    </mat-dialog-actions>
+  `,
+  styles: [`
+    mat-dialog-content { min-width: 480px; max-width: 640px; max-height: 60vh; }
+    .bulk-upload-row { display: flex; align-items: center; gap: 12px; margin-bottom: 16px; }
+    .upload-hint { color: #888; font-size: 0.82rem; }
+    .bulk-filter-row { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin-bottom: 8px; }
+    .bulk-filter-field { flex: 1; min-width: 180px; }
+    .preview-row { display: flex; align-items: center; gap: 12px; margin: 4px 0; }
+    .name-field { flex: 1; }
+    .capacity-warning { display: flex; align-items: center; gap: 6px; color: #c62828; font-weight: 500; margin: 8px 0; }
+    .capacity-warning mat-icon { font-size: 18px; width: 18px; height: 18px; }
+  `],
+})
+export class BulkRegisterDialogComponent {
+  storePlayerPool: PlayerDto[];
+  selectedPlayerIds = new Set<number>();
+  playerFilterText = '';
+
+  showPreview = false;
+  previewData: BulkRegisterPreviewDto | null = null;
+  previewSelected: Record<number, boolean> = {};
+  unknownNames: Record<string, string> = {};
+  unknownIncluded: Record<string, boolean> = {};
+
+  constructor(
+    @Inject(MAT_DIALOG_DATA) public data: BulkRegisterDialogData,
+    private dialogRef: MatDialogRef<BulkRegisterDialogComponent, BulkRegisterResultDto | undefined>,
+    private api: ApiService,
+    private ctx: LocalStorageContext,
+    public cdr: ChangeDetectorRef,
+  ) {
+    this.storePlayerPool = this.ctx.players.getAll();
+  }
+
+  get filteredPool(): PlayerDto[] {
+    const s = this.playerFilterText.toLowerCase();
+    return this.storePlayerPool.filter(p =>
+      p.name.toLowerCase().includes(s) || p.email.toLowerCase().includes(s),
+    );
+  }
+
+  get previewOverCapacity(): boolean {
+    if (!this.previewData) return false;
+    const willRegister =
+      this.previewData.found.filter(f => this.previewSelected[f.playerId]).length +
+      this.previewData.notFound.filter(e => this.unknownIncluded[e]).length;
+    return willRegister > this.data.availableSlots;
+  }
+
+  toggleSelectAll(select: boolean): void {
+    if (select) {
+      this.filteredPool.forEach(p => this.selectedPlayerIds.add(p.id));
+    } else {
+      this.selectedPlayerIds.clear();
+    }
+    this.cdr.detectChanges();
+  }
+
+  onFileSelected(event: Event): void {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      const lines = (reader.result as string)
+        .split('\n')
+        .map(l => l.trim().toLowerCase())
+        .filter(l => l.length > 0 && l !== 'email');
+
+      const all = this.ctx.players.getAll();
+      const found: BulkRegisterFoundDto[] = [];
+      const notFound: string[] = [];
+      const alreadyRegistered: BulkRegisterFoundDto[] = [];
+
+      for (const email of lines) {
+        const player = all.find(p => p.email.toLowerCase() === email);
+        if (!player) {
+          notFound.push(email);
+        } else if (this.data.registeredPlayerIds.has(player.id)) {
+          alreadyRegistered.push({ playerId: player.id, name: player.name, email: player.email });
+        } else {
+          found.push({ playerId: player.id, name: player.name, email: player.email });
+        }
+      }
+
+      this.previewData     = { found, notFound, alreadyRegistered };
+      this.previewSelected = Object.fromEntries(found.map(f => [f.playerId, true]));
+      this.unknownNames    = Object.fromEntries(notFound.map(e => [e, '']));
+      this.unknownIncluded = Object.fromEntries(notFound.map(e => [e, true]));
+      this.showPreview     = true;
+      this.cdr.detectChanges();
+    };
+    reader.readAsText(file);
+  }
+
+  onRegisterSelected(): void {
+    const found: BulkRegisterFoundDto[] = [];
+    const alreadyRegistered: BulkRegisterFoundDto[] = [];
+    for (const id of this.selectedPlayerIds) {
+      const player = this.ctx.players.getById(id);
+      if (!player) continue;
+      if (this.data.registeredPlayerIds.has(id)) {
+        alreadyRegistered.push({ playerId: id, name: player.name, email: player.email });
+      } else {
+        found.push({ playerId: id, name: player.name, email: player.email });
+      }
+    }
+    this.previewData     = { found, notFound: [], alreadyRegistered };
+    this.previewSelected = Object.fromEntries(found.map(f => [f.playerId, true]));
+    this.showPreview     = true;
+    this.cdr.detectChanges();
+  }
+
+  confirm(): void {
+    if (!this.previewData || this.previewOverCapacity) return;
+    const registrations: BulkRegisterConfirmDto['registrations'] = [
+      ...this.previewData.found
+        .filter(f => this.previewSelected[f.playerId])
+        .map(f => ({ playerId: f.playerId, email: f.email })),
+      ...this.previewData.notFound
+        .filter(e => this.unknownIncluded[e])
+        .map(e => ({ playerId: null, email: e, name: this.unknownNames[e] || null })),
+    ];
+    this.api.bulkRegisterConfirm(this.data.eventId, { registrations }).subscribe({
+      next: result => {
+        this.dialogRef.close(result);
+      },
+      error: () => {
+        this.dialogRef.close(undefined);
+      },
+    });
+  }
+
+  cancelPreview(): void {
+    this.showPreview  = false;
+    this.previewData  = null;
+    this.cdr.detectChanges();
+  }
+
+  cancel(): void {
+    this.dialogRef.close(undefined);
+  }
+}

--- a/tournament-client/src/app/features/events/event-detail.component.spec.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.spec.ts
@@ -8,11 +8,10 @@ import { EventDetailComponent } from './event-detail.component';
 import { EventService } from '../../core/services/event.service';
 import { PlayerService } from '../../core/services/player.service';
 import { AuthService } from '../../core/services/auth.service';
-import { ApiService } from '../../core/services/api.service';
-import { LocalStorageContext } from '../../core/services/local-storage-context.service';
+import { MatDialog } from '@angular/material/dialog';
+import { Subject } from 'rxjs';
 import {
   EventDto, EventPlayerDto, PlayerDto, RoundDto, StandingsEntry,
-  BulkRegisterConfirmDto, BulkRegisterResultDto,
 } from '../../core/models/api.models';
 
 describe('EventDetailComponent', () => {
@@ -74,10 +73,8 @@ describe('EventDetailComponent', () => {
     loadAllPlayers: jest.Mock;
   };
 
-  let mockSnackBar:   { open: jest.Mock };
-  let mockRouter:     { navigate: jest.Mock };
-  let mockApiService: { bulkRegisterConfirm: jest.Mock };
-  let mockCtx:        { players: { getAll: jest.Mock; getById: jest.Mock } };
+  let mockSnackBar: { open: jest.Mock };
+  let mockRouter:   { navigate: jest.Mock };
 
   async function setup(authOverrides: object = {}) {
     const mockAuth = {
@@ -101,8 +98,6 @@ describe('EventDetailComponent', () => {
         { provide: PlayerService,        useValue: mockPlayerService },
         { provide: AuthService,          useValue: mockAuth },
         { provide: MatSnackBar,          useValue: mockSnackBar },
-        { provide: ApiService,           useValue: mockApiService },
-        { provide: LocalStorageContext,  useValue: mockCtx },
       ],
     }).compileComponents();
   }
@@ -149,8 +144,6 @@ describe('EventDetailComponent', () => {
       createUrlTree: jest.fn().mockReturnValue({}),
       serializeUrl: jest.fn().mockReturnValue('/fake'),
     };
-    mockApiService = { bulkRegisterConfirm: jest.fn().mockReturnValue(of({ registered: 0, created: 0, errors: [] })) };
-    mockCtx = { players: { getAll: jest.fn().mockReturnValue([]), getById: jest.fn().mockReturnValue(null) } };
   });
 
   // ── Smoke ───────────────────────────────────────────────────────────────────
@@ -1032,258 +1025,93 @@ describe('EventDetailComponent', () => {
     });
   });
 
-  // ── Bulk Register ─────────────────────────────────────────────────────────
+  // ── Bulk Register dialog ───────────────────────────────────────────────────
 
   describe('Bulk Register', () => {
     const regEvent: EventDto = { ...eventStub, status: 'Registration' };
 
-    const alicePlayer: PlayerDto = {
-      id: 10, name: 'Alice Manager', email: 'alice@shop.com',
-      mu: 25, sigma: 8.333, conservativeScore: 0, isRanked: false, placementGamesLeft: 5, isActive: true,
-    };
-
-    const bobPlayer: PlayerDto = {
-      id: 11, name: 'Bob Player', email: 'bob@example.com',
-      mu: 25, sigma: 8.333, conservativeScore: 0, isRanked: false, placementGamesLeft: 5, isActive: true,
-    };
-
-    // Fake FileReader that calls onload synchronously
-    let fakeFileContent = '';
-    class MockFileReader {
-      result: string = '';
-      onload: (() => void) | null = null;
-      readAsText(_file: File) {
-        this.result = fakeFileContent;
-        this.onload?.();
-      }
-    }
-
-    beforeEach(() => {
-      (global as any).FileReader = MockFileReader;
-    });
-
-    it('Upload File button is visible for StoreEmployee when event is in Registration', async () => {
+    it('Bulk Register Players button is visible for StoreEmployee', async () => {
       await setup({ isStoreEmployee: true });
       const fixture = TestBed.createComponent(EventDetailComponent);
       fixture.detectChanges();
       currentEventSubject.next(regEvent);
       fixture.detectChanges();
-
       const el: HTMLElement = fixture.nativeElement;
-      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Upload File'));
+      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Bulk Register'));
       expect(btn).toBeTruthy();
     });
 
-    it('Upload File button is NOT visible for Player role', async () => {
+    it('Bulk Register Players button is NOT visible for Player role', async () => {
       await setup({ isStoreEmployee: false });
       const fixture = TestBed.createComponent(EventDetailComponent);
       fixture.detectChanges();
       currentEventSubject.next(regEvent);
       fixture.detectChanges();
-
       const el: HTMLElement = fixture.nativeElement;
-      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Upload File'));
+      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Bulk Register'));
       expect(btn).toBeFalsy();
     });
 
-    it('Register Selected button is disabled when no players checked', async () => {
+    it('clicking Bulk Register opens MatDialog with correct data', async () => {
       await setup({ isStoreEmployee: true });
       const fixture = TestBed.createComponent(EventDetailComponent);
       fixture.detectChanges();
-      currentEventSubject.next(regEvent);
+      currentEventSubject.next({ ...regEvent, maxPlayers: 8, playerCount: 4 });
       fixture.detectChanges();
 
-      const el: HTMLElement = fixture.nativeElement;
-      const btn = Array.from(el.querySelectorAll('button')).find(b => b.textContent?.includes('Register Selected')) as HTMLButtonElement | undefined;
-      expect(btn).toBeTruthy();
-      expect(btn?.disabled).toBe(true);
-    });
+      const dialogOpenSpy = jest.spyOn((fixture.componentInstance as any).dialog, 'open')
+        .mockReturnValue({ afterClosed: () => of(undefined) });
 
-    it('Register Selected button is enabled when at least one player is checked', async () => {
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
+      fixture.componentInstance.openBulkRegisterDialog();
 
-      const comp = fixture.componentInstance;
-      comp.selectedPlayerIds.add(alicePlayer.id);
-
-      // Verify the bound expression that controls disabled
-      expect(comp.selectedPlayerIds.size).toBeGreaterThan(0);
-    });
-
-    it('onBulkFileSelected resolves found players without calling apiService', async () => {
-      fakeFileContent = 'alice@shop.com\n';
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-
-      expect(mockApiService.bulkRegisterConfirm).not.toHaveBeenCalled();
-      expect(fixture.componentInstance.previewData?.found.length).toBe(1);
-      expect(fixture.componentInstance.previewData?.found[0].email).toBe('alice@shop.com');
-    });
-
-    it('onBulkFileSelected puts email not in cache into previewData.notFound', async () => {
-      fakeFileContent = 'unknown@example.com\n';
-      mockCtx.players.getAll.mockReturnValue([]);
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-
-      expect(fixture.componentInstance.previewData?.notFound).toContain('unknown@example.com');
-    });
-
-    it('onBulkFileSelected puts already-registered player into previewData.alreadyRegistered', async () => {
-      fakeFileContent = 'alice@shop.com\n';
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      // alice is already registered
-      eventPlayersSubject.next([{ ...epStub, playerId: alicePlayer.id }]);
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-
-      expect(fixture.componentInstance.previewData?.alreadyRegistered.length).toBe(1);
-      expect(fixture.componentInstance.previewData?.found.length).toBe(0);
-    });
-
-    it('preview panel is absent before file upload or Register Selected', async () => {
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const el: HTMLElement = fixture.nativeElement;
-      const headings = Array.from(el.querySelectorAll('h3'));
-      expect(headings.some(h => h.textContent?.includes('Preview Registration'))).toBe(false);
-    });
-
-    it('preview panel shows after file upload', async () => {
-      fakeFileContent = 'alice@shop.com\n';
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-      fixture.detectChanges();
-
-      const el: HTMLElement = fixture.nativeElement;
-      const headings = Array.from(el.querySelectorAll('h3'));
-      expect(headings.some(h => h.textContent?.includes('Preview Registration'))).toBe(true);
-    });
-
-    it('cancelPreview hides the preview panel', async () => {
-      fakeFileContent = 'alice@shop.com\n';
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-      fixture.detectChanges();
-
-      fixture.componentInstance.cancelPreview();
-      fixture.detectChanges();
-
-      const el: HTMLElement = fixture.nativeElement;
-      const headings = Array.from(el.querySelectorAll('h3'));
-      expect(headings.some(h => h.textContent?.includes('Preview Registration'))).toBe(false);
-    });
-
-    it('confirmBulkRegistration calls apiService.bulkRegisterConfirm with correct payload', async () => {
-      fakeFileContent = 'alice@shop.com\n';
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      mockApiService.bulkRegisterConfirm.mockReturnValue(of({ registered: 1, created: 0, errors: [] }));
-      await setup({ isStoreEmployee: true });
-      const fixture = TestBed.createComponent(EventDetailComponent);
-      fixture.detectChanges();
-      currentEventSubject.next(regEvent);
-      fixture.detectChanges();
-
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-      fixture.detectChanges();
-
-      fixture.componentInstance.confirmBulkRegistration();
-
-      expect(mockApiService.bulkRegisterConfirm).toHaveBeenCalledWith(
-        EVENT_ID,
+      expect(dialogOpenSpy).toHaveBeenCalledWith(
+        expect.anything(),
         expect.objectContaining({
-          registrations: expect.arrayContaining([
-            expect.objectContaining({ playerId: alicePlayer.id, email: alicePlayer.email }),
-          ]),
+          data: expect.objectContaining({ eventId: EVENT_ID, availableSlots: 4 }),
         }),
       );
     });
 
-    it('snackbar shows summary after successful confirmBulkRegistration', async () => {
-      fakeFileContent = 'alice@shop.com\n';
-      mockCtx.players.getAll.mockReturnValue([alicePlayer]);
-      mockApiService.bulkRegisterConfirm.mockReturnValue(of({ registered: 2, created: 1, errors: [] } as BulkRegisterResultDto));
+    it('after dialog closes with result, snackbar shows summary and event reloads', async () => {
       await setup({ isStoreEmployee: true });
       const fixture = TestBed.createComponent(EventDetailComponent);
       fixture.detectChanges();
       currentEventSubject.next(regEvent);
       fixture.detectChanges();
 
-      const snackBarOpenSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open')
-        .mockReturnValue({} as any);
+      const closeSubject = new Subject<{ registered: number; created: number; errors: [] }>();
+      jest.spyOn((fixture.componentInstance as any).dialog, 'open')
+        .mockReturnValue({ afterClosed: () => closeSubject.asObservable() });
+      const snackBarOpenSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open').mockReturnValue({} as any);
 
-      const fakeEvent = { target: { files: [new File([''], 'test.txt')] } } as unknown as Event;
-      fixture.componentInstance.onBulkFileSelected(fakeEvent);
-      fixture.detectChanges();
-      fixture.componentInstance.confirmBulkRegistration();
+      fixture.componentInstance.openBulkRegisterDialog();
+      closeSubject.next({ registered: 3, created: 1, errors: [] });
 
       expect(snackBarOpenSpy).toHaveBeenCalledWith(
-        expect.stringContaining('2 registered'),
+        expect.stringContaining('3 registered'),
         'OK',
         expect.any(Object),
       );
+      expect(mockEventService.loadEventPlayers).toHaveBeenCalledWith(EVENT_ID);
+      expect(mockEventService.loadEvent).toHaveBeenCalledWith(EVENT_ID);
     });
 
-    it('onRegisterSelected builds preview from selectedPlayerIds without calling apiService', async () => {
-      mockCtx.players.getAll.mockReturnValue([alicePlayer, bobPlayer]);
-      mockCtx.players.getById.mockImplementation((id: number) =>
-        id === alicePlayer.id ? alicePlayer : id === bobPlayer.id ? bobPlayer : null,
-      );
+    it('after dialog closes with undefined (cancel), no snackbar or reload', async () => {
       await setup({ isStoreEmployee: true });
       const fixture = TestBed.createComponent(EventDetailComponent);
       fixture.detectChanges();
       currentEventSubject.next(regEvent);
       fixture.detectChanges();
 
-      const comp = fixture.componentInstance;
-      comp.selectedPlayerIds.add(alicePlayer.id);
-      comp.onRegisterSelected();
+      const closeSubject = new Subject<undefined>();
+      jest.spyOn((fixture.componentInstance as any).dialog, 'open')
+        .mockReturnValue({ afterClosed: () => closeSubject.asObservable() });
+      const snackBarOpenSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open').mockReturnValue({} as any);
 
-      expect(mockApiService.bulkRegisterConfirm).not.toHaveBeenCalled();
-      expect(comp.showPreview).toBe(true);
-      expect(comp.previewData?.found.length).toBe(1);
+      fixture.componentInstance.openBulkRegisterDialog();
+      closeSubject.next(undefined);
+
+      expect(snackBarOpenSpy).not.toHaveBeenCalled();
     });
   });
 });

--- a/tournament-client/src/app/features/events/event-detail.component.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.ts
@@ -14,19 +14,17 @@ import { MatAutocompleteModule, MatAutocompleteSelectedEvent } from '@angular/ma
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatCheckboxModule } from '@angular/material/checkbox';
 import { MatCardModule } from '@angular/material/card';
-import { MatListModule } from '@angular/material/list';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import * as QRCode from 'qrcode';
 import { EventService } from '../../core/services/event.service';
 import { PlayerService } from '../../core/services/player.service';
 import { AuthService } from '../../core/services/auth.service';
-import { ApiService } from '../../core/services/api.service';
-import { LocalStorageContext } from '../../core/services/local-storage-context.service';
 import {
   EventDto, RoundDto, StandingsEntry, EventPlayerDto, PlayerDto, POINT_SYSTEM_LABELS,
-  BulkRegisterFoundDto, BulkRegisterPreviewDto,
 } from '../../core/models/api.models';
 import { PodCardComponent, PodResultState } from './pod-card.component';
 import { EventStandingsComponent } from './event-standings.component';
+import { BulkRegisterDialogComponent } from './dialogs/bulk-register-dialog.component';
 
 @Component({
   selector: 'app-event-detail',
@@ -36,7 +34,7 @@ import { EventStandingsComponent } from './event-standings.component';
     MatTableModule, MatChipsModule, MatExpansionModule, MatIconModule,
     MatAutocompleteModule, MatSnackBarModule,
     PodCardComponent, EventStandingsComponent,
-    MatCheckboxModule, MatCardModule, MatListModule,
+    MatCheckboxModule, MatCardModule, MatDialogModule,
   ],
   template: `
     @if (event) {
@@ -171,91 +169,9 @@ import { EventStandingsComponent } from './event-standings.component';
 
                 <!-- ── Bulk Register ── -->
                 <div class="bulk-register-section">
-                  <h4>Bulk Register</h4>
-
-                  <!-- File upload -->
-                  <div class="bulk-upload-row">
-                    <button mat-stroked-button (click)="bulkFileInput.click()">
-                      <mat-icon>upload_file</mat-icon> Upload File
-                    </button>
-                    <input #bulkFileInput type="file" accept=".txt,.csv"
-                           style="display:none"
-                           (change)="onBulkFileSelected($event)">
-                  </div>
-
-                  <!-- Multi-select from store player pool -->
-                  <div class="bulk-multiselect">
-                    <div class="bulk-filter-row">
-                      <mat-form-field class="bulk-filter-field">
-                        <mat-label>Filter Players</mat-label>
-                        <input matInput [(ngModel)]="playerFilterText" (ngModelChange)="detect()">
-                      </mat-form-field>
-                      <button mat-button (click)="toggleSelectAll(true)">Select All</button>
-                      <button mat-button (click)="toggleSelectAll(false)">Deselect All</button>
-                    </div>
-                    <mat-selection-list>
-                      @for (p of filteredPlayerPool; track p.id) {
-                        <mat-list-option
-                          [selected]="selectedPlayerIds.has(p.id)"
-                          (selectedChange)="$event ? selectedPlayerIds.add(p.id) : selectedPlayerIds.delete(p.id); detect()">
-                          {{ p.name }} — {{ p.email }}
-                        </mat-list-option>
-                      }
-                    </mat-selection-list>
-                    <button mat-raised-button color="primary"
-                            [disabled]="selectedPlayerIds.size === 0"
-                            (click)="onRegisterSelected()">
-                      Register Selected
-                    </button>
-                  </div>
-
-                  <!-- Preview panel -->
-                  @if (showPreview && previewData) {
-                    <div class="bulk-preview-panel">
-                      <h3>Preview Registration</h3>
-
-                      @if (previewData.found.length > 0) {
-                        <p><strong>Will register ({{ previewData.found.length }}):</strong></p>
-                        @for (f of previewData.found; track f.playerId) {
-                          <div class="preview-row">
-                            <mat-checkbox [(ngModel)]="previewSelected[f.playerId]" (ngModelChange)="detect()">
-                              {{ f.name }} — {{ f.email }}
-                            </mat-checkbox>
-                          </div>
-                        }
-                      }
-
-                      @if (previewData.notFound.length > 0) {
-                        <p><strong>New players to create ({{ previewData.notFound.length }}):</strong></p>
-                        @for (email of previewData.notFound; track email) {
-                          <div class="preview-row">
-                            <mat-checkbox [(ngModel)]="unknownIncluded[email]" (ngModelChange)="detect()">
-                              {{ email }}
-                            </mat-checkbox>
-                            <mat-form-field class="name-field">
-                              <mat-label>Name for {{ email }}</mat-label>
-                              <input matInput [(ngModel)]="unknownNames[email]">
-                            </mat-form-field>
-                          </div>
-                        }
-                      }
-
-                      @if (previewData.alreadyRegistered.length > 0) {
-                        <p><strong>Already registered (skipped):</strong>
-                          @for (a of previewData.alreadyRegistered; track a.playerId) {
-                            <span> {{ a.email }}</span>
-                          }
-                        </p>
-                      }
-
-                      <div class="preview-actions">
-                        <button mat-raised-button color="primary" (click)="confirmBulkRegistration()">
-                          Confirm Registration
-                        </button>
-                        <button mat-button (click)="cancelPreview()">Cancel</button>
-                      </div>
-                    </div>
-                  }
+                  <button mat-stroked-button (click)="openBulkRegisterDialog()">
+                    <mat-icon>group_add</mat-icon> Bulk Register Players
+                  </button>
                 </div>
               }
               @if (!authService.isStoreEmployee && authService.currentUser?.playerId && !isAlreadyRegistered(authService.currentUser!.playerId!) && !isEventFull) {
@@ -566,26 +482,7 @@ export class EventDetailComponent implements OnInit {
   editingCommanderPlayerId: number | null = null;
   editCommanderValue = '';
 
-  // ── Bulk Register ─────────────────────────────────────────────────────────
-  storePlayerPool: PlayerDto[] = [];
-  selectedPlayerIds = new Set<number>();
-  playerFilterText = '';
-  showPreview = false;
-  previewData: BulkRegisterPreviewDto | null = null;
-  unknownNames: Record<string, string> = {};
-  unknownIncluded: Record<string, boolean> = {};
-  previewSelected: Record<number, boolean> = {};
   private registeredPlayerIds = new Set<number>();
-
-  /** Called from template event handlers that need a detectChanges() call. */
-  detect(): void { this.cdr.detectChanges(); }
-
-  get filteredPlayerPool(): PlayerDto[] {
-    const search = this.playerFilterText.toLowerCase();
-    return this.storePlayerPool.filter(p =>
-      p.name.toLowerCase().includes(search) || p.email.toLowerCase().includes(search),
-    );
-  }
 
   constructor(
     private route: ActivatedRoute,
@@ -595,8 +492,7 @@ export class EventDetailComponent implements OnInit {
     private snackBar: MatSnackBar,
     private cdr: ChangeDetectorRef,
     public authService: AuthService,
-    private apiService: ApiService,
-    private ctx: LocalStorageContext,
+    private dialog: MatDialog,
   ) {}
 
   ngOnInit() {
@@ -638,7 +534,6 @@ export class EventDetailComponent implements OnInit {
     this.eventService.loadRounds(this.eventId);
     this.playerService.loadAllPlayers();
     this.loadStandings();
-    this.storePlayerPool = this.ctx.players.getAll();
   }
 
   private syncPodStates(rounds: RoundDto[]) {
@@ -1044,105 +939,29 @@ export class EventDetailComponent implements OnInit {
     }
   }
 
-  // ── Bulk Register methods ─────────────────────────────────────────────────
+  // ── Bulk Register ─────────────────────────────────────────────────────────
 
-  onBulkFileSelected(event: Event): void {
-    const file = (event.target as HTMLInputElement).files?.[0];
-    if (!file) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      const lines = (reader.result as string)
-        .split('\n')
-        .map(l => l.trim().toLowerCase())
-        .filter(l => l.length > 0 && l !== 'email');
+  openBulkRegisterDialog(): void {
+    const availableSlots = this.event?.maxPlayers
+      ? this.event.maxPlayers - this.event.playerCount
+      : Infinity;
 
-      const allPlayers = this.ctx.players.getAll();
-      const found: BulkRegisterFoundDto[] = [];
-      const notFound: string[] = [];
-      const alreadyRegistered: BulkRegisterFoundDto[] = [];
-
-      for (const email of lines) {
-        const player = allPlayers.find(p => p.email.toLowerCase() === email);
-        if (!player) {
-          notFound.push(email);
-        } else if (this.registeredPlayerIds.has(player.id)) {
-          alreadyRegistered.push({ playerId: player.id, name: player.name, email: player.email });
-        } else {
-          found.push({ playerId: player.id, name: player.name, email: player.email });
-        }
-      }
-
-      this.previewData = { found, notFound, alreadyRegistered };
-      this.previewSelected = Object.fromEntries(found.map(f => [f.playerId, true]));
-      this.unknownNames    = Object.fromEntries(notFound.map(e => [e, '']));
-      this.unknownIncluded = Object.fromEntries(notFound.map(e => [e, true]));
-      this.showPreview = true;
-      this.cdr.detectChanges();
-    };
-    reader.readAsText(file);
-  }
-
-  onRegisterSelected(): void {
-    const found: BulkRegisterFoundDto[] = [];
-    const alreadyRegistered: BulkRegisterFoundDto[] = [];
-    for (const id of this.selectedPlayerIds) {
-      const player = this.ctx.players.getById(id);
-      if (!player) continue;
-      if (this.registeredPlayerIds.has(id)) {
-        alreadyRegistered.push({ playerId: id, name: player.name, email: player.email });
-      } else {
-        found.push({ playerId: id, name: player.name, email: player.email });
-      }
-    }
-    this.previewData = { found, notFound: [], alreadyRegistered };
-    this.previewSelected = Object.fromEntries(found.map(f => [f.playerId, true]));
-    this.showPreview = true;
-    this.cdr.detectChanges();
-  }
-
-  confirmBulkRegistration(): void {
-    if (!this.previewData) return;
-    const registrations = [
-      // Found players whose checkbox is still checked
-      ...this.previewData.found
-        .filter(f => this.previewSelected[f.playerId])
-        .map(f => ({ playerId: f.playerId, email: f.email })),
-      // Unknown emails that the user has included and filled in a name for
-      ...this.previewData.notFound
-        .filter(e => this.unknownIncluded[e])
-        .map(e => ({ playerId: null, email: e, name: this.unknownNames[e] || null })),
-    ];
-
-    this.apiService.bulkRegisterConfirm(this.eventId, { registrations }).subscribe({
-      next: (result) => {
-        const msg = `${result.registered} registered, ${result.created} new players created`;
-        this.snackBar.open(msg, 'OK', { duration: 5000 });
-        this.showPreview = false;
-        this.previewData = null;
-        this.selectedPlayerIds.clear();
-        this.eventService.loadEventPlayers(this.eventId);
-        this.eventService.loadEvent(this.eventId);
-        this.cdr.detectChanges();
-      },
-      error: (err) => {
-        this.snackBar.open(err.error?.error || 'Bulk registration failed', 'OK', { duration: 4000 });
-        this.cdr.detectChanges();
+    const ref = this.dialog.open(BulkRegisterDialogComponent, {
+      width: '680px',
+      data: {
+        eventId: this.eventId,
+        availableSlots,
+        registeredPlayerIds: new Set(this.registeredPlayerIds),
       },
     });
-  }
 
-  cancelPreview(): void {
-    this.showPreview = false;
-    this.previewData = null;
-    this.cdr.detectChanges();
-  }
-
-  toggleSelectAll(selectAll: boolean): void {
-    if (selectAll) {
-      this.filteredPlayerPool.forEach(p => this.selectedPlayerIds.add(p.id));
-    } else {
-      this.selectedPlayerIds.clear();
-    }
-    this.cdr.detectChanges();
+    ref.afterClosed().subscribe(result => {
+      if (!result) return;
+      const msg = `${result.registered} registered, ${result.created} new players created`;
+      this.snackBar.open(msg, 'OK', { duration: 5000 });
+      this.eventService.loadEventPlayers(this.eventId);
+      this.eventService.loadEvent(this.eventId);
+      this.cdr.detectChanges();
+    });
   }
 }


### PR DESCRIPTION
## Summary
- Extracted the inline bulk register UI from `event-detail` into a standalone `BulkRegisterDialogComponent` opened via `MatDialog`, reducing screen real estate usage
- Added a capacity guard: when the selected player count exceeds `availableSlots` (derived from `maxPlayers - playerCount`), the Confirm button is disabled and a warning is shown in the preview panel
- Added 12 unit tests for `BulkRegisterDialogComponent` and updated `event-detail` tests to reflect the dialog-based flow
- Removed leftover `LocalStorageContext` injection from `EventDetailComponent` (now only used inside the dialog)

## Test plan
- [ ] Jest: `npx jest --config jest.config.js --testPathPatterns=bulk-register-dialog` — 12 tests pass
- [ ] Jest: `npx jest --config jest.config.js --testPathPatterns=event-detail.component` — 96 tests pass
- [ ] Open an event in Registration status as a Store Employee — "Bulk Register Players" button is visible
- [ ] Click the button — dialog opens with player list, filter, Select All / Deselect All
- [ ] Upload a CSV file — preview panel shows found / not-found / already-registered sections
- [ ] Select more players than `availableSlots` — capacity warning appears and Confirm is disabled
- [ ] Deselect players to fit within capacity — warning disappears and Confirm re-enables
- [ ] Confirm registration — snackbar shows "N registered, M new players created", player list reloads
- [ ] Cancel or press Back — dialog closes with no side effects
- [ ] Player role — "Bulk Register Players" button is not visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)