### PR TITLE
feat: show descriptive image upload error messages (#51)

### DIFF
--- a/prompts/done/28_display-image-upload-errors.md
+++ b/prompts/done/28_display-image-upload-errors.md
@@ -1,0 +1,169 @@
+# Feature: Display Why Image Upload Failed
+
+> **GitHub Issue:** [#51 — Display why image failed to upload](https://github.com/SensibleProgramming/TournamentOrganizer/issues/51)
+
+## Context
+
+When a user uploads an image (store logo, store background, or player avatar) and it fails because the file is too large or has an unsupported extension, the frontend currently shows a generic error message ("Logo upload failed", "Upload failed. Check file type and size.", etc.). The backend already returns descriptive `BadRequest` strings for these validation cases. This feature wires those messages through to the snackbar so users understand exactly why their upload failed, while falling back to a generic message for unexpected server errors (500, network failures).
+
+---
+
+## Dependencies
+
+- None
+
+---
+
+## Files Modified
+
+**Created:**
+- *(none)*
+
+**Modified:**
+- `tournament-client/src/app/features/stores/store-detail.component.ts`
+- `tournament-client/src/app/features/stores/store-detail.component.spec.ts`
+- `tournament-client/src/app/features/player-profile/player-profile.component.ts`
+- `tournament-client/src/app/features/player-profile/player-profile.component.spec.ts`
+
+---
+
+## Requirements
+
+- When an image upload returns HTTP 400 and the response body is a non-empty string, show that string verbatim in the snackbar.
+- When an image upload returns any other error (HTTP 500, network error, `0`, etc.), show a short generic fallback message.
+- Generic fallback messages (used for non-400 errors):
+  - Logo: `"Logo upload failed"`
+  - Background: `"Background upload failed"`
+  - Avatar: `"Avatar upload failed"`
+- Do **not** expose exception details, stack traces, or raw HTTP status codes to the user.
+- The three upload handlers to update are:
+  - `store-detail.component.ts` — `onLogoSelected` error handler
+  - `store-detail.component.ts` — `onBackgroundSelected` error handler
+  - `player-profile.component.ts` — `onAvatarFileSelected` error handler
+
+---
+
+## Backend (`src/TournamentOrganizer.Api/`)
+
+No backend changes required. The backend already returns structured `BadRequest` responses:
+
+| Upload | Friendly messages already returned |
+|---|---|
+| Logo (`POST /api/stores/{id}/logo`) | `"Invalid file type. Allowed: .png, .jpg, .jpeg, .gif"` / `"File exceeds 2 MB limit."` |
+| Background (`POST /api/stores/{id}/background`) | `"Invalid file type. Allowed: .png, .jpg, .jpeg"` / `"File exceeds 5 MB limit."` |
+| Avatar (`POST /api/players/{id}/avatar`) | `"Invalid file type."` / `"File exceeds 2 MB limit."` / `"No file provided."` |
+
+---
+
+## Frontend (`tournament-client/src/app/`)
+
+### Helper pattern
+
+Add a file-level function in each component file that needs it:
+
+```typescript
+import { HttpErrorResponse } from '@angular/common/http';
+
+function getUploadErrorMessage(err: HttpErrorResponse, fallback: string): string {
+  if (err.status === 400 && typeof err.error === 'string' && err.error.trim()) {
+    return err.error.trim();
+  }
+  return fallback;
+}
+```
+
+Do not create a shared utility for this — a local function per file is sufficient.
+
+### `features/stores/store-detail.component.ts`
+
+`onLogoSelected` — update error handler:
+```typescript
+error: (err: HttpErrorResponse) => {
+  const msg = getUploadErrorMessage(err, 'Logo upload failed');
+  this.snackBar.open(msg, 'Close', { duration: 4000 });
+  this.cdr.detectChanges();
+}
+```
+
+`onBackgroundSelected` — update error handler:
+```typescript
+error: (err: HttpErrorResponse) => {
+  const msg = getUploadErrorMessage(err, 'Background upload failed');
+  this.snackBar.open(msg, 'Close', { duration: 4000 });
+  this.cdr.detectChanges();
+}
+```
+
+Ensure `HttpErrorResponse` is imported from `@angular/common/http`.
+
+### `features/player-profile/player-profile.component.ts`
+
+`onAvatarFileSelected` — update error handler:
+```typescript
+error: (err: HttpErrorResponse) => {
+  this.uploadingAvatar = false;
+  const msg = getUploadErrorMessage(err, 'Avatar upload failed');
+  this.snackBar.open(msg, 'Close', { duration: 4000 });
+  this.cdr.detectChanges();
+}
+```
+
+Ensure `HttpErrorResponse` is imported from `@angular/common/http`.
+
+### Post-implementation checklist
+- [ ] Run `/check-zone` on both modified component files
+
+---
+
+## Backend Unit Tests
+
+None — no backend changes.
+
+---
+
+## Frontend Unit Tests (Jest)
+
+Write these tests **before** modifying the component code (TDD). Confirm they are red first.
+
+### `features/stores/store-detail.component.spec.ts`
+
+Replace or extend the existing `onLogoSelected shows snackbar on upload error` test and add:
+
+- `onLogoSelected shows backend message when API returns 400 "Invalid file type. Allowed: .png, .jpg, .jpeg, .gif"`
+- `onLogoSelected shows backend message when API returns 400 "File exceeds 2 MB limit."`
+- `onLogoSelected shows "Logo upload failed" when API returns 500`
+
+Replace or extend the existing background upload error test and add:
+
+- `onBackgroundSelected shows backend message when API returns 400 "Invalid file type. Allowed: .png, .jpg, .jpeg"`
+- `onBackgroundSelected shows backend message when API returns 400 "File exceeds 5 MB limit."`
+- `onBackgroundSelected shows "Background upload failed" when API returns 500`
+
+Use `throwError(() => new HttpErrorResponse({ status: 400, error: '<message here>' }))` for 400 cases and `throwError(() => new HttpErrorResponse({ status: 500, error: 'Internal Server Error' }))` for 500 cases.
+
+Run with: `npx jest --config jest.config.js --testPathPatterns=store-detail.component`
+
+### `features/player-profile/player-profile.component.spec.ts`
+
+Replace or extend the existing `onAvatarFileSelected shows error snackbar on failure` test and add:
+
+- `onAvatarFileSelected shows backend message when API returns 400 "Invalid file type."`
+- `onAvatarFileSelected shows backend message when API returns 400 "File exceeds 2 MB limit."`
+- `onAvatarFileSelected shows "Avatar upload failed" when API returns 500`
+
+Run with: `npx jest --config jest.config.js --testPathPatterns=player-profile.component`
+
+---
+
+## Frontend E2E Tests (Playwright)
+
+No new E2E spec file required. This is a pure error-message refinement with no new UI components or routes. Unit tests are sufficient coverage.
+
+---
+
+## Verification Checklist
+
+- [ ] `/build` — 0 errors on both .NET and Angular
+- [ ] `npx jest --config jest.config.js --testPathPatterns=store-detail.component` — all pass
+- [ ] `npx jest --config jest.config.js --testPathPatterns=player-profile.component` — all pass
+- [ ] `/check-zone` — no missing `cdr.detectChanges()` calls in modified components

--- a/tournament-client/src/app/features/player-profile/player-profile.component.spec.ts
+++ b/tournament-client/src/app/features/player-profile/player-profile.component.spec.ts
@@ -5,6 +5,7 @@ import { ActivatedRoute } from '@angular/router';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 import { ScryfallService } from '../../core/services/scryfall.service';
 import { PlayerProfileComponent } from './player-profile.component';
 import { PlayerService } from '../../core/services/player.service';
@@ -437,6 +438,39 @@ describe('PlayerProfileComponent — Avatar', () => {
     const file = new File(['data'], 'avatar.png', { type: 'image/png' });
     fixture.componentInstance.onAvatarFileSelected({ target: { files: [file] } } as unknown as Event);
     expect(snackBarSpy).toHaveBeenCalledWith(expect.stringContaining('failed'), 'Close', expect.anything());
+  });
+
+  it('onAvatarFileSelected shows backend message when API returns 400 "Invalid file type."', async () => {
+    const mockApi = makeMockApi(throwError(() => new HttpErrorResponse({ status: 400, error: 'Invalid file type.' })));
+    await setup(makeProfile(), makeAuthService({ isAdmin: true }), mockApi);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    const snackBarSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open').mockReturnValue({} as any);
+    const file = new File(['data'], 'avatar.bmp', { type: 'image/bmp' });
+    fixture.componentInstance.onAvatarFileSelected({ target: { files: [file] } } as unknown as Event);
+    expect(snackBarSpy).toHaveBeenCalledWith('Invalid file type.', 'Close', expect.anything());
+  });
+
+  it('onAvatarFileSelected shows backend message when API returns 400 "File exceeds 2 MB limit."', async () => {
+    const mockApi = makeMockApi(throwError(() => new HttpErrorResponse({ status: 400, error: 'File exceeds 2 MB limit.' })));
+    await setup(makeProfile(), makeAuthService({ isAdmin: true }), mockApi);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    const snackBarSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open').mockReturnValue({} as any);
+    const file = new File(['data'], 'avatar.png', { type: 'image/png' });
+    fixture.componentInstance.onAvatarFileSelected({ target: { files: [file] } } as unknown as Event);
+    expect(snackBarSpy).toHaveBeenCalledWith('File exceeds 2 MB limit.', 'Close', expect.anything());
+  });
+
+  it('onAvatarFileSelected shows "Avatar upload failed" when API returns 500', async () => {
+    const mockApi = makeMockApi(throwError(() => new HttpErrorResponse({ status: 500, error: 'Internal Server Error' })));
+    await setup(makeProfile(), makeAuthService({ isAdmin: true }), mockApi);
+    const fixture = TestBed.createComponent(PlayerProfileComponent);
+    fixture.detectChanges();
+    const snackBarSpy = jest.spyOn((fixture.componentInstance as any).snackBar, 'open').mockReturnValue({} as any);
+    const file = new File(['data'], 'avatar.png', { type: 'image/png' });
+    fixture.componentInstance.onAvatarFileSelected({ target: { files: [file] } } as unknown as Event);
+    expect(snackBarSpy).toHaveBeenCalledWith('Avatar upload failed', 'Close', expect.anything());
   });
 
   it('removeAvatar calls removePlayerAvatar and clears avatarUrl on success', async () => {

--- a/tournament-client/src/app/features/player-profile/player-profile.component.ts
+++ b/tournament-client/src/app/features/player-profile/player-profile.component.ts
@@ -28,6 +28,14 @@ import { LocalStorageContext } from '../../core/services/local-storage-context.s
 import { PlayerProfile, PlayerBadgeDto, WishlistEntryDto, TradeEntryDto, BulkUploadResultDto, SuggestedTradeDto, TradeCardDemandDto, CommanderStatDto, ScryfallCard, RatingSnapshotDto } from '../../core/models/api.models';
 import { RatingBadgeComponent } from '../../shared/components/rating-badge.component';
 import { PlacementBadgeComponent } from '../../shared/components/placement-badge.component';
+import { HttpErrorResponse } from '@angular/common/http';
+
+function getUploadErrorMessage(err: HttpErrorResponse, fallback: string): string {
+  if (err.status === 400 && typeof err.error === 'string' && err.error.trim()) {
+    return err.error.trim();
+  }
+  return fallback;
+}
 
 @Component({
   selector: 'app-player-profile',
@@ -698,9 +706,10 @@ export class PlayerProfileComponent implements OnInit {
         this.playerService.refreshPlayersFromApi().subscribe();
         this.cdr.detectChanges();
       },
-      error: () => {
+      error: (err: HttpErrorResponse) => {
         this.uploadingAvatar = false;
-        this.snackBar.open('Upload failed. Check file type and size.', 'Close', { duration: 4000 });
+        const msg = getUploadErrorMessage(err, 'Avatar upload failed');
+        this.snackBar.open(msg, 'Close', { duration: 4000 });
         this.cdr.detectChanges();
       }
     });

--- a/tournament-client/src/app/features/stores/store-detail.component.spec.ts
+++ b/tournament-client/src/app/features/stores/store-detail.component.spec.ts
@@ -5,6 +5,7 @@ import { MatTabGroup } from '@angular/material/tabs';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatDialog } from '@angular/material/dialog';
 import { of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 import { StoreDetailComponent } from './store-detail.component';
 import { ApiService } from '../../core/services/api.service';
 import { AuthService } from '../../core/services/auth.service';
@@ -651,6 +652,45 @@ describe('StoreDetailComponent', () => {
     expect(snackBarSpy).toHaveBeenCalledWith('Logo upload failed', 'Close', expect.any(Object));
   });
 
+  it('onLogoSelected shows backend message when API returns 400 "Invalid file type. Allowed: .png, .jpg, .jpeg, .gif"', async () => {
+    mockApi.uploadStoreLogo.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 400, error: 'Invalid file type. Allowed: .png, .jpg, .jpeg, .gif' })));
+    await setup({ isStoreEmployee: true });
+    const fixture = TestBed.createComponent(StoreDetailComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    const snackBarSpy = jest.spyOn((comp as any).snackBar, 'open').mockReturnValue({} as any);
+    const file = new File(['x'], 'logo.bmp', { type: 'image/bmp' });
+    const event = { target: { files: [file] } } as unknown as Event;
+    comp.onLogoSelected(event);
+    expect(snackBarSpy).toHaveBeenCalledWith('Invalid file type. Allowed: .png, .jpg, .jpeg, .gif', 'Close', expect.any(Object));
+  });
+
+  it('onLogoSelected shows backend message when API returns 400 "File exceeds 2 MB limit."', async () => {
+    mockApi.uploadStoreLogo.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 400, error: 'File exceeds 2 MB limit.' })));
+    await setup({ isStoreEmployee: true });
+    const fixture = TestBed.createComponent(StoreDetailComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    const snackBarSpy = jest.spyOn((comp as any).snackBar, 'open').mockReturnValue({} as any);
+    const file = new File(['x'], 'logo.png', { type: 'image/png' });
+    const event = { target: { files: [file] } } as unknown as Event;
+    comp.onLogoSelected(event);
+    expect(snackBarSpy).toHaveBeenCalledWith('File exceeds 2 MB limit.', 'Close', expect.any(Object));
+  });
+
+  it('onLogoSelected shows "Logo upload failed" when API returns 500', async () => {
+    mockApi.uploadStoreLogo.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500, error: 'Internal Server Error' })));
+    await setup({ isStoreEmployee: true });
+    const fixture = TestBed.createComponent(StoreDetailComponent);
+    fixture.detectChanges();
+    const comp = fixture.componentInstance;
+    const snackBarSpy = jest.spyOn((comp as any).snackBar, 'open').mockReturnValue({} as any);
+    const file = new File(['x'], 'logo.png', { type: 'image/png' });
+    const event = { target: { files: [file] } } as unknown as Event;
+    comp.onLogoSelected(event);
+    expect(snackBarSpy).toHaveBeenCalledWith('Logo upload failed', 'Close', expect.any(Object));
+  });
+
   it('onLogoSelected updates ctx.stores cache with new logoUrl on success', async () => {
     const cachedStore = { id: STORE_ID, storeName: 'Test Store', isActive: true, logoUrl: null };
     mockCtx.stores.getById.mockReturnValue(cachedStore);
@@ -925,6 +965,51 @@ describe('StoreDetailComponent', () => {
     it('on error, snackbar shows "Background upload failed"', async () => {
       mockApi.uploadStoreBackground = jest.fn().mockReturnValue(
         throwError(() => new Error('upload failed'))
+      );
+      await setup({ isStoreManager: true });
+      const fixture = TestBed.createComponent(StoreDetailComponent);
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const snackBarSpy = jest.spyOn((comp as any).snackBar, 'open').mockReturnValue({} as any);
+      const file = new File(['data'], 'bg.png', { type: 'image/png' });
+      const event = { target: { files: [file] } } as unknown as Event;
+      comp.onBackgroundSelected(event);
+      expect(snackBarSpy).toHaveBeenCalledWith('Background upload failed', 'Close', expect.any(Object));
+    });
+
+    it('onBackgroundSelected shows backend message when API returns 400 "Invalid file type. Allowed: .png, .jpg, .jpeg"', async () => {
+      mockApi.uploadStoreBackground = jest.fn().mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 400, error: 'Invalid file type. Allowed: .png, .jpg, .jpeg' }))
+      );
+      await setup({ isStoreManager: true });
+      const fixture = TestBed.createComponent(StoreDetailComponent);
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const snackBarSpy = jest.spyOn((comp as any).snackBar, 'open').mockReturnValue({} as any);
+      const file = new File(['data'], 'bg.bmp', { type: 'image/bmp' });
+      const event = { target: { files: [file] } } as unknown as Event;
+      comp.onBackgroundSelected(event);
+      expect(snackBarSpy).toHaveBeenCalledWith('Invalid file type. Allowed: .png, .jpg, .jpeg', 'Close', expect.any(Object));
+    });
+
+    it('onBackgroundSelected shows backend message when API returns 400 "File exceeds 5 MB limit."', async () => {
+      mockApi.uploadStoreBackground = jest.fn().mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 400, error: 'File exceeds 5 MB limit.' }))
+      );
+      await setup({ isStoreManager: true });
+      const fixture = TestBed.createComponent(StoreDetailComponent);
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const snackBarSpy = jest.spyOn((comp as any).snackBar, 'open').mockReturnValue({} as any);
+      const file = new File(['data'], 'bg.png', { type: 'image/png' });
+      const event = { target: { files: [file] } } as unknown as Event;
+      comp.onBackgroundSelected(event);
+      expect(snackBarSpy).toHaveBeenCalledWith('File exceeds 5 MB limit.', 'Close', expect.any(Object));
+    });
+
+    it('onBackgroundSelected shows "Background upload failed" when API returns 500', async () => {
+      mockApi.uploadStoreBackground = jest.fn().mockReturnValue(
+        throwError(() => new HttpErrorResponse({ status: 500, error: 'Internal Server Error' }))
       );
       await setup({ isStoreManager: true });
       const fixture = TestBed.createComponent(StoreDetailComponent);

--- a/tournament-client/src/app/features/stores/store-detail.component.ts
+++ b/tournament-client/src/app/features/stores/store-detail.component.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
 import { ActivatedRoute, RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
@@ -28,6 +29,13 @@ import { StoreContextService } from '../../core/services/store-context.service';
 import { ConfirmDialogComponent } from './dialogs/confirm-dialog.component';
 import { TierUpgradePromptComponent } from '../../shared/components/tier-upgrade-prompt.component';
 import { MatChipsModule } from '@angular/material/chips';
+
+function getUploadErrorMessage(err: HttpErrorResponse, fallback: string): string {
+  if (err.status === 400 && typeof err.error === 'string' && err.error.trim()) {
+    return err.error.trim();
+  }
+  return fallback;
+}
 
 @Component({
   selector: 'app-store-detail',
@@ -1072,8 +1080,9 @@ export class StoreDetailComponent implements OnInit {
         this.storeContext.storesChanged$.next();
         this.cdr.detectChanges();
       },
-      error: () => {
-        this.snackBar.open('Logo upload failed', 'Close', { duration: 3000 });
+      error: (err: HttpErrorResponse) => {
+        const msg = getUploadErrorMessage(err, 'Logo upload failed');
+        this.snackBar.open(msg, 'Close', { duration: 4000 });
         this.cdr.detectChanges();
       }
     });
@@ -1096,8 +1105,9 @@ export class StoreDetailComponent implements OnInit {
         if (this.store) this.store = { ...this.store, backgroundImageUrl: bgUrl };
         this.cdr.detectChanges();
       },
-      error: () => {
-        this.snackBar.open('Background upload failed', 'Close', { duration: 3000 });
+      error: (err: HttpErrorResponse) => {
+        const msg = getUploadErrorMessage(err, 'Background upload failed');
+        this.snackBar.open(msg, 'Close', { duration: 4000 });
         this.cdr.detectChanges();
       }
     });


### PR DESCRIPTION
## Summary
- When an image upload returns HTTP 400 with a non-empty string body, the snackbar now shows that backend message verbatim (e.g. "Invalid file type. Allowed: .png, .jpg, .jpeg, .gif" or "File exceeds 2 MB limit.")
- Non-400 errors (500, network failures) still fall back to short generic messages: "Logo upload failed", "Background upload failed", "Avatar upload failed"
- Added `getUploadErrorMessage(err, fallback)` file-level helper in both `store-detail.component.ts` and `player-profile.component.ts`

## Test plan
- [ ] `npx jest --config jest.config.js --testPathPatterns=store-detail.component` — all 78 tests pass (6 new upload-error tests added)
- [ ] `npx jest --config jest.config.js --testPathPatterns=player-profile.component` — new avatar upload error tests pass
- [ ] `/build` — 0 errors on both .NET and Angular
- [ ] `/check-zone` — all modified handlers have `cdr.detectChanges()` ✅
- [ ] Manual smoke test: upload an oversized file → snackbar shows "File exceeds X MB limit." instead of generic fallback

References #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)