### PR TITLE
feat: restrict GET /api/stores/{id} to StoreEmployee+ with ownership check

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/StoresController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/StoresController.cs
@@ -37,8 +37,15 @@ public class StoresController : ControllerBase
         => Ok(await _service.GetAllAsync());
 
     [HttpGet("{id}")]
+    [Authorize(Policy = "StoreEmployee")]
     public async Task<ActionResult<StoreDetailDto>> GetById(int id)
     {
+        // Admin can read any store; StoreEmployee/Manager can only read their own.
+        if (!User.HasClaim("role", "Administrator"))
+        {
+            var jwtStoreId = int.TryParse(User.FindFirstValue("storeId"), out var s) ? s : 0;
+            if (jwtStoreId != id) return Forbid();
+        }
         var store = await _service.GetByIdAsync(id);
         return store == null ? NotFound() : Ok(store);
     }

--- a/src/TournamentOrganizer.Tests/CrossStoreAccessTests.cs
+++ b/src/TournamentOrganizer.Tests/CrossStoreAccessTests.cs
@@ -36,6 +36,52 @@ public class CrossStoreAccessTests(TournamentOrganizerFactory factory)
             $"Expected 403 Forbidden but got {(int)response.StatusCode}");
 
     // ══════════════════════════════════════════════════════════════════════════
+    // StoresController — GET /api/stores/{id}
+    // StoreEmployee policy + explicit storeId ownership check
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Player_GetStore_Returns403()
+    {
+        // Player role does not satisfy StoreEmployee policy.
+        var client = factory.ClientAs("Player", playerId: 1);
+        var response = await client.GetAsync("/api/stores/1");
+        AssertForbidden(response);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_GetStore_Returns401()
+    {
+        var client = factory.CreateClient(); // no JWT
+        var response = await client.GetAsync("/api/stores/1");
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task StoreEmployee_Store1_GetStore2_Returns403()
+    {
+        var client = factory.ClientAs("StoreEmployee", storeId: 1);
+        var response = await client.GetAsync("/api/stores/2");
+        AssertForbidden(response);
+    }
+
+    [Fact]
+    public async Task StoreEmployee_GetOwnStore_IsAllowed()
+    {
+        var client = factory.ClientAs("StoreEmployee", storeId: 1);
+        var response = await client.GetAsync("/api/stores/1");
+        AssertAllowed(response);
+    }
+
+    [Fact]
+    public async Task Administrator_GetAnyStore_IsAllowed()
+    {
+        var client = factory.ClientAs("Administrator");
+        var response = await client.GetAsync("/api/stores/2");
+        AssertAllowed(response);
+    }
+
+    // ══════════════════════════════════════════════════════════════════════════
     // StoresController — PUT /api/stores/{id}
     // StoreManager policy + explicit storeId ownership check
     // ══════════════════════════════════════════════════════════════════════════

--- a/tournament-client/e2e/stores/cross-store-access.spec.ts
+++ b/tournament-client/e2e/stores/cross-store-access.spec.ts
@@ -1,0 +1,66 @@
+import { test, expect } from '@playwright/test';
+import { loginAs } from '../helpers/auth';
+import {
+  stubUnmatchedApi,
+  mockGetStores,
+  mockGetThemes,
+  makeStoreDto,
+} from '../helpers/api-mock';
+
+// ─── Cross-Store Access E2E Tests ─────────────────────────────────────────────
+//
+// Verifies that a StoreEmployee of store A cannot load store B's detail page.
+// The API now requires StoreEmployee policy on GET /api/stores/{id} and enforces
+// storeId ownership — so a cross-store request returns 403.
+//
+// The frontend should redirect to /stores and show an "Access denied" snackbar
+// when the API returns 403 on the store load.
+
+// ── StoreEmployee: cross-store navigation redirects ───────────────────────────
+
+test.describe('Cross-store access — StoreEmployee redirected from foreign store', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: 1 });
+    await stubUnmatchedApi(page);
+    await mockGetThemes(page, []);
+    await mockGetStores(page, [
+      makeStoreDto({ id: 1, storeName: 'Own Store' }),
+      makeStoreDto({ id: 2, storeName: 'Other Store' }),
+    ]);
+    // Mock GET /api/stores/2 → 403 Forbidden
+    await page.route('**/api/stores/2', route => {
+      if (route.request().method() === 'GET') {
+        route.fulfill({ status: 403, body: 'Forbidden' });
+      } else {
+        route.continue();
+      }
+    });
+  });
+
+  test('navigating to a foreign store redirects to /stores', async ({ page }) => {
+    await page.goto('/stores/2');
+    await expect(page).toHaveURL(/\/stores$/, { timeout: 5000 });
+  });
+
+  test('an "Access denied" snackbar is shown after forbidden store load', async ({ page }) => {
+    await page.goto('/stores/2');
+    await expect(page.locator('mat-snack-bar-container')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('mat-snack-bar-container')).toContainText(/Access denied/i);
+  });
+});
+
+// ── StoreEmployee: own store loads normally ────────────────────────────────────
+
+test.describe('Cross-store access — StoreEmployee can load own store', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, 'StoreEmployee', { storeId: 1 });
+    await stubUnmatchedApi(page);
+    await mockGetThemes(page, []);
+  });
+
+  test('StoreEmployee navigating to own store sees the store page', async ({ page }) => {
+    await page.goto('/stores/1');
+    // stubUnmatchedApi returns {} for the store — component renders normally (no redirect)
+    await expect(page).toHaveURL(/\/stores\/1/, { timeout: 5000 });
+  });
+});

--- a/tournament-client/src/app/features/stores/store-detail.component.ts
+++ b/tournament-client/src/app/features/stores/store-detail.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, ChangeDetectorRef } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { FormsModule } from '@angular/forms';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { MatCardModule } from '@angular/material/card';
 import { MatButtonModule } from '@angular/material/button';
 import { MatIconModule } from '@angular/material/icon';
@@ -689,6 +689,7 @@ export class StoreDetailComponent implements OnInit {
 
   constructor(
     private route:        ActivatedRoute,
+    private router:       Router,
     private apiService:   ApiService,
     private snackBar:     MatSnackBar,
     private cdr:          ChangeDetectorRef,
@@ -742,7 +743,12 @@ export class StoreDetailComponent implements OnInit {
           this.loadTemplates();
         }
       },
-      error: () => {
+      error: (err) => {
+        if (err?.status === 403) {
+          this.snackBar.open('Access denied', 'OK', { duration: 4000 });
+          this.router.navigate(['/stores']);
+          return;
+        }
         this.apiOnline = false;
         // Fall back to the locally-cached store so the page renders offline
         const cached = this.ctx.stores.getById(this.storeId);


### PR DESCRIPTION
## Summary
- `GET /api/stores/{id}` now requires `[Authorize(Policy = "StoreEmployee")]` — unauthenticated users and Players get 401/403
- Admin can read any store; StoreEmployee/Manager can only read their own store (same ownership-check pattern as PUT/meta endpoints)
- Frontend `store-detail` component detects 403 and redirects to `/stores` with an "Access denied" snackbar instead of silently going offline

## Test plan
- [x] Backend: `Player_GetStore_Returns403`, `Unauthenticated_GetStore_Returns401`, `StoreEmployee_Store1_GetStore2_Returns403`, `StoreEmployee_GetOwnStore_IsAllowed`, `Administrator_GetAnyStore_IsAllowed` — all pass
- [x] E2E: `cross-store-access.spec.ts` — redirect + snackbar on 403; own-store loads normally — all pass
- [x] `dotnet build` — 0 errors
- [x] `ng build` — 0 errors
- [x] Full stores E2E suite: 145 passed (2 pre-existing store-logo file-chooser failures unrelated to this change)

References #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)