### PR TITLE
fix: store-logo E2E tests missing licenseTier causing filechooser timeout

### DIFF
--- a/tournament-client/e2e/stores/store-logo.spec.ts
+++ b/tournament-client/e2e/stores/store-logo.spec.ts
@@ -72,7 +72,7 @@ test.describe('Store logo — toolbar display', () => {
 
 test.describe('Store logo — upload refreshes store-detail image', () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, 'StoreEmployee');
+    await loginAs(page, 'StoreEmployee', { storeId: STORE_ID, licenseTier: 'Tier1' });
     await stubUnmatchedApi(page);
     await mockGetStores(page, [makeStoreDto({ id: STORE_ID, storeName: 'Logo Test Shop' })]);
     await mockGetStore(page, STORE_WITH_LOGO);
@@ -139,7 +139,7 @@ test.describe('Store logo — upload refreshes toolbar thumbnail', () => {
 
 test.describe('Store logo — persists after Save Settings', () => {
   test.beforeEach(async ({ page }) => {
-    await loginAs(page, 'StoreManager');
+    await loginAs(page, 'StoreManager', { storeId: STORE_ID, licenseTier: 'Tier1' });
     await stubUnmatchedApi(page);
     await mockGetStores(page, [makeStoreDto({ id: STORE_ID, storeName: 'Logo Test Shop', logoUrl: OLD_LOGO })]);
     await mockGetStore(page, STORE_WITH_LOGO);


### PR DESCRIPTION
## Summary
- Two store-logo E2E tests were timing out on `page.waitForEvent('filechooser')`
- Root cause: `loginAs(page, 'StoreEmployee')` and `loginAs(page, 'StoreManager')` were called without `licenseTier`, so `authService.isTier1` was false
- The "Change Logo" button is guarded by `@if (authService.isStoreEmployee && authService.isTier1)` — with no tier the button never rendered, so clicking it never triggered a file chooser
- Fix: added `{ storeId: STORE_ID, licenseTier: 'Tier1' }` to both affected `beforeEach` calls

## Test plan
- [x] All 336 E2E tests pass (including the 2 previously broken store-logo tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)