### PR TITLE
fix(security): JWT delivered via URL fragment in OAuth callback

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/AuthController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/AuthController.cs
@@ -14,8 +14,13 @@ namespace TournamentOrganizer.Api.Controllers;
 public class AuthController : ControllerBase
 {
     private readonly IAuthService _authService;
+    private readonly IConfiguration _configuration;
 
-    public AuthController(IAuthService authService) => _authService = authService;
+    public AuthController(IAuthService authService, IConfiguration configuration)
+    {
+        _authService = authService;
+        _configuration = configuration;
+    }
 
     [HttpGet("google-login")]
     public IActionResult GoogleLogin()
@@ -41,7 +46,8 @@ public class AuthController : ControllerBase
         var user = await _authService.FindOrCreateUserAsync(email, name ?? email, googleId);
         var token = await _authService.GenerateJwtAsync(user);
 
-        return Redirect($"http://localhost:4200/auth/callback?token={token}");
+        var frontendBase = _configuration["Frontend:BaseUrl"] ?? "http://localhost:4200";
+        return Redirect($"{frontendBase}/auth/callback#token={Uri.EscapeDataString(token)}");
     }
 
     [HttpGet("me")]

--- a/tournament-client/e2e/auth/oauth-callback.spec.ts
+++ b/tournament-client/e2e/auth/oauth-callback.spec.ts
@@ -1,0 +1,72 @@
+import { test, expect } from '@playwright/test';
+import { stubUnmatchedApi } from '../helpers/api-mock';
+
+// ─── OAuth Callback E2E Tests ─────────────────────────────────────────────────
+//
+// Verifies that the token is delivered via URL fragment (not query string),
+// stored to localStorage, and that the fragment is removed from the address bar
+// before any redirect occurs (OWASP A02:2021 — tokens must not appear in logs
+// or browser history).
+//
+// The component does a full-page reload via window.location.href, so we wait
+// for the final URL rather than asserting on intermediate states.
+
+// Minimal decodable JWT (same shape as auth.ts makeJwt)
+function makeJwt(payload: Record<string, unknown>): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'HS256', typ: 'JWT' })).toString('base64');
+  const body   = Buffer.from(JSON.stringify(payload)).toString('base64');
+  return `${header}.${body}.stub-signature`;
+}
+
+const STUB_TOKEN = makeJwt({
+  sub: '1',
+  email: 'test-player@example.com',
+  name: 'Test Player',
+  role: 'Player',
+  exp: Math.floor(Date.now() / 1000) + 3600,
+});
+
+test.describe('OAuth callback — token via URL fragment', () => {
+  test('stores the token in localStorage and redirects to /', async ({ page }) => {
+    await stubUnmatchedApi(page);
+
+    await page.goto(`/auth/callback#token=${encodeURIComponent(STUB_TOKEN)}`);
+
+    // After the full-page reload the app should land on root
+    await expect(page).toHaveURL('/', { timeout: 5000 });
+
+    // Token must be in localStorage
+    const stored = await page.evaluate(() => localStorage.getItem('auth_token'));
+    expect(stored).toBe(STUB_TOKEN);
+  });
+
+  test('URL does not contain the token as a query parameter', async ({ page }) => {
+    await stubUnmatchedApi(page);
+
+    await page.goto(`/auth/callback#token=${encodeURIComponent(STUB_TOKEN)}`);
+
+    await expect(page).toHaveURL('/', { timeout: 5000 });
+
+    // The token must never appear as a query param — it must only travel as a fragment
+    const url = page.url();
+    expect(url).not.toContain('token=');
+  });
+});
+
+test.describe('OAuth callback — error path', () => {
+  test('redirects to / when no token is present', async ({ page }) => {
+    await stubUnmatchedApi(page);
+
+    await page.goto('/auth/callback?error=auth_failed');
+
+    await expect(page).toHaveURL('/', { timeout: 5000 });
+  });
+
+  test('redirects to / when neither token nor error is present', async ({ page }) => {
+    await stubUnmatchedApi(page);
+
+    await page.goto('/auth/callback');
+
+    await expect(page).toHaveURL('/', { timeout: 5000 });
+  });
+});

--- a/tournament-client/src/app/features/auth/oauth-callback.component.spec.ts
+++ b/tournament-client/src/app/features/auth/oauth-callback.component.spec.ts
@@ -12,6 +12,11 @@ import { AuthService } from '../../core/services/auth.service';
 // spy on its _locationObjectSetterNavigate method, which is called (with the
 // parsed URL object) every time location.href is set. Spying on the *instance*
 // (not a prototype) is immune to Jest's per-file module isolation.
+//
+// Note: we do NOT set window.location.hash in tests because JSDOM's hash setter
+// also routes through _locationObjectSetterNavigate, which our spy intercepts
+// before the actual URL update is applied. Instead, we spy on the component's
+// protected readLocationHash() method.
 
 function getLocationImpl(): any {
   const implSym = Object.getOwnPropertySymbols(window.location)
@@ -28,16 +33,20 @@ function isRootPath(parsedUrl: { path?: string[] }): boolean {
 }
 
 let navigateSpy: jest.SpyInstance;
+let replaceStateSpy: jest.SpyInstance;
 
 beforeEach(() => {
   const impl = getLocationImpl();
   navigateSpy = jest
     .spyOn(impl, '_locationObjectSetterNavigate')
     .mockImplementation(() => {}); // suppress JSDOM "not implemented: navigation" noise
+
+  replaceStateSpy = jest.spyOn(history, 'replaceState').mockImplementation(() => {});
 });
 
 afterEach(() => {
   navigateSpy.mockRestore();
+  replaceStateSpy.mockRestore();
 });
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
@@ -57,16 +66,28 @@ describe('OAuthCallbackComponent', () => {
     mockAuthService = { storeToken: jest.fn() };
   });
 
-  function setup(params: Record<string, string>) {
+  /**
+   * Creates the component without triggering ngOnInit.
+   * Call fixture.detectChanges() after setting any spies.
+   */
+  function createComponent(queryParams: Record<string, string>) {
     TestBed.configureTestingModule({
       imports: [OAuthCallbackComponent],
       providers: [
-        { provide: ActivatedRoute, useValue: makeRoute(params) },
+        { provide: ActivatedRoute, useValue: makeRoute(queryParams) },
         { provide: AuthService, useValue: mockAuthService },
       ],
     });
+    return TestBed.createComponent(OAuthCallbackComponent);
+  }
 
-    const fixture = TestBed.createComponent(OAuthCallbackComponent);
+  /** Creates and initialises the component with an optional hash fragment. */
+  function setup(queryParams: Record<string, string>, hashValue = '') {
+    const fixture = createComponent(queryParams);
+    if (hashValue) {
+      jest.spyOn(fixture.componentInstance as any, 'readLocationHash')
+        .mockReturnValue(hashValue);
+    }
     fixture.detectChanges(); // triggers ngOnInit
     return fixture;
   }
@@ -74,54 +95,63 @@ describe('OAuthCallbackComponent', () => {
   // ─── Creation ─────────────────────────────────────────────────────────
 
   it('should create', () => {
-    expect(setup({ token: 'abc' }).componentInstance).toBeTruthy();
+    expect(setup({}, '#token=abc').componentInstance).toBeTruthy();
   });
 
   it('renders the "Signing in…" message', () => {
-    const fixture = setup({ token: 'abc' });
+    const fixture = setup({}, '#token=abc');
     expect(fixture.nativeElement.textContent).toContain('Signing in');
   });
 
-  // ─── Token present path ────────────────────────────────────────────────
+  // ─── Token present path (token in URL hash) ────────────────────────────
 
-  it('calls authService.storeToken with the provided token', () => {
-    setup({ token: 'my-jwt-token' });
+  it('calls authService.storeToken with the hash token', () => {
+    setup({}, '#token=my-jwt-token');
     expect(mockAuthService.storeToken).toHaveBeenCalledWith('my-jwt-token');
     expect(mockAuthService.storeToken).toHaveBeenCalledTimes(1);
   });
 
-  it('redirects to "/" after storing the token', () => {
-    setup({ token: 'my-jwt-token' });
+  it('clears the hash from the URL bar after reading the token', () => {
+    setup({}, '#token=my-jwt-token');
+    expect(replaceStateSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('redirects to "/" after storing the hash token', () => {
+    setup({}, '#token=my-jwt-token');
     expect(navigateSpy).toHaveBeenCalledTimes(1);
     const [parsedUrl] = navigateSpy.mock.calls[0];
     expect(isRootPath(parsedUrl)).toBe(true);
   });
 
   it('stores the token before redirecting', () => {
+    const fixture = createComponent({});
+    jest.spyOn(fixture.componentInstance as any, 'readLocationHash')
+      .mockReturnValue('#token=my-jwt-token');
+
     const order: string[] = [];
     mockAuthService.storeToken.mockImplementation(() => order.push('storeToken'));
     navigateSpy.mockImplementation(() => order.push('redirect'));
 
-    setup({ token: 'my-jwt-token' });
+    fixture.detectChanges(); // triggers ngOnInit
 
     expect(order).toEqual(['storeToken', 'redirect']);
   });
 
-  // ─── Error / no-token path ─────────────────────────────────────────────
-
-  it('does NOT call storeToken when token param is absent', () => {
+  it('does NOT call storeToken when hash token is absent', () => {
     setup({ error: 'access_denied' });
     expect(mockAuthService.storeToken).not.toHaveBeenCalled();
   });
 
-  it('redirects to "/" when there is no token', () => {
+  // ─── Error / no-token path ─────────────────────────────────────────────
+
+  it('redirects to "/" when there is no hash token', () => {
     setup({ error: 'access_denied' });
     expect(navigateSpy).toHaveBeenCalledTimes(1);
     const [parsedUrl] = navigateSpy.mock.calls[0];
     expect(isRootPath(parsedUrl)).toBe(true);
   });
 
-  it('redirects to "/" when both token and error are absent', () => {
+  it('redirects to "/" when both hash token and error are absent', () => {
     setup({});
     expect(navigateSpy).toHaveBeenCalledTimes(1);
     const [parsedUrl] = navigateSpy.mock.calls[0];

--- a/tournament-client/src/app/features/auth/oauth-callback.component.ts
+++ b/tournament-client/src/app/features/auth/oauth-callback.component.ts
@@ -16,8 +16,18 @@ export class OAuthCallbackComponent implements OnInit {
   ) {}
 
   ngOnInit(): void {
-    const token = this.route.snapshot.queryParamMap.get('token');
+    // Token is delivered via URL fragment (#token=...) so it is never sent
+    // to the server or recorded in access logs (OWASP A02:2021).
+    const hash = this.readLocationHash();
+    const hashParams = new URLSearchParams(hash.slice(1));
+    const token = hashParams.get('token');
     const error = this.route.snapshot.queryParamMap.get('error');
+
+    // Immediately clear the fragment from the address bar so it cannot be
+    // bookmarked, copy-pasted, or leaked via the Referer header.
+    if (hash) {
+      history.replaceState(null, '', window.location.pathname + window.location.search);
+    }
 
     if (token) {
       this.authService.storeToken(token);
@@ -30,5 +40,11 @@ export class OAuthCallbackComponent implements OnInit {
       console.error('OAuth callback error:', error);
       window.location.href = '/';
     }
+  }
+
+  // Extracted for testability: JSDOM's location setter spy intercepts hash
+  // assignments before they take effect, so tests spy on this method instead.
+  protected readLocationHash(): string {
+    return window.location.hash;
   }
 }


### PR DESCRIPTION
## Summary
- `AuthController.GoogleCallback` now redirects with `#token=...` (URL fragment) instead of `?token=...` (query param), so the JWT is never sent to the server, logged in access logs, or forwarded in Referer headers
- `OAuthCallbackComponent` reads the token from `window.location.hash`, calls `history.replaceState` to clear the fragment immediately, then stores the token and redirects
- `IConfiguration` injected into `AuthController` to support a `Frontend:BaseUrl` config key (defaults to `http://localhost:4200`)

## Test plan
- [ ] Backend: existing `dotnet test` suite still passes
- [ ] Frontend Jest: `oauth-callback.component.spec.ts` — 11 tests covering hash token read, `replaceState` call, store-before-redirect ordering, and error paths
- [ ] Playwright E2E: `e2e/auth/oauth-callback.spec.ts` — 4 tests confirming token stored in localStorage, URL has no `token=` query param after redirect, and error/empty cases redirect to `/`

References #85

🤖 Generated with [Claude Code](https://claude.com/claude-code)