### PR TITLE
fix(security): validate Discord webhook URL to prevent SSRF

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/StoresController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/StoresController.cs
@@ -69,8 +69,15 @@ public class StoresController : ControllerBase
             var jwtStoreId = int.TryParse(User.FindFirstValue("storeId"), out var s) ? s : 0;
             if (jwtStoreId != id) return Forbid();
         }
-        var store = await _service.UpdateAsync(id, dto);
-        return store == null ? NotFound() : Ok(store);
+        try
+        {
+            var store = await _service.UpdateAsync(id, dto);
+            return store == null ? NotFound() : Ok(store);
+        }
+        catch (ArgumentException ex)
+        {
+            return BadRequest(ex.Message);
+        }
     }
 
     [HttpPost("{id}/logo")]

--- a/src/TournamentOrganizer.Api/Services/DiscordWebhookService.cs
+++ b/src/TournamentOrganizer.Api/Services/DiscordWebhookService.cs
@@ -143,6 +143,15 @@ public class DiscordWebhookService : IDiscordWebhookService
 
     private async Task PostEmbedAsync(string webhookUrl, string title, string description, string footerText)
     {
+        // Defense-in-depth: only allow HTTPS requests to discord.com to prevent SSRF
+        if (!Uri.TryCreate(webhookUrl, UriKind.Absolute, out var uri)
+            || !uri.Host.EndsWith("discord.com", StringComparison.OrdinalIgnoreCase)
+            || uri.Scheme != "https")
+        {
+            _logger.LogWarning("Blocked outbound request to non-Discord URL: {Url}", webhookUrl);
+            return;
+        }
+
         var payload = new
         {
             embeds = new[]

--- a/src/TournamentOrganizer.Api/Services/StoresService.cs
+++ b/src/TournamentOrganizer.Api/Services/StoresService.cs
@@ -56,7 +56,16 @@ public class StoresService : IStoresService
         store.UpdatedOn = DateTime.UtcNow;
         // null = no change; empty string = clear the webhook URL
         if (dto.DiscordWebhookUrl != null)
+        {
+            if (dto.DiscordWebhookUrl != string.Empty)
+            {
+                if (!Uri.TryCreate(dto.DiscordWebhookUrl, UriKind.Absolute, out var uri)
+                    || !uri.Host.EndsWith("discord.com", StringComparison.OrdinalIgnoreCase)
+                    || uri.Scheme != "https")
+                    throw new ArgumentException("Discord webhook URL must be an https://discord.com webhook.");
+            }
             store.DiscordWebhookUrl = dto.DiscordWebhookUrl == string.Empty ? null : dto.DiscordWebhookUrl;
+        }
         // Generate slug on first update if not already set
         if (store.Slug == null)
             store.Slug = await EnsureUniqueSlugAsync(GenerateSlug(store.StoreName), store.Id);

--- a/src/TournamentOrganizer.Tests/DiscordWebhookServiceTests.cs
+++ b/src/TournamentOrganizer.Tests/DiscordWebhookServiceTests.cs
@@ -217,6 +217,38 @@ public class DiscordWebhookServiceTests
         Assert.Contains("Alice", body);
     }
 
+    // ── SSRF defence-in-depth tests ───────────────────────────────────────────
+
+    [Theory]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://localhost:5021/admin/")]
+    [InlineData("https://evil.com/steal")]
+    [InlineData("http://discord.com/api/webhooks/123/abc")]
+    public async Task PostTestMessageAsync_WithNonDiscordOrHttpUrl_DoesNotPost(string badUrl)
+    {
+        var storeRepo = new FakeStoreRepository { StoreToReturn = new Store { Id = 1, StoreName = "Shop", DiscordWebhookUrl = badUrl } };
+        var handler = new CapturingHandler();
+        var svc = BuildService(storeRepo, new FakeStoreEventRepository(), new FakeEventRepository(), new FakePlayerRepository(), handler);
+
+        await svc.PostTestMessageAsync(1);
+
+        Assert.Null(handler.LastRequest);
+    }
+
+    [Fact]
+    public async Task PostTestMessageAsync_WithValidDiscordUrl_Posts()
+    {
+        const string webhookUrl = "https://discord.com/api/webhooks/999/xyz";
+        var storeRepo = new FakeStoreRepository { StoreToReturn = new Store { Id = 1, StoreName = "Shop", DiscordWebhookUrl = webhookUrl } };
+        var handler = new CapturingHandler();
+        var svc = BuildService(storeRepo, new FakeStoreEventRepository(), new FakeEventRepository(), new FakePlayerRepository(), handler);
+
+        await svc.PostTestMessageAsync(1);
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(webhookUrl, handler.LastRequest!.RequestUri!.ToString());
+    }
+
     // ── Helpers ──────────────────────────────────────────────────────────────
 
     private static Round MakeRound(int roundNumber) => new()

--- a/src/TournamentOrganizer.Tests/StoresServiceTests.cs
+++ b/src/TournamentOrganizer.Tests/StoresServiceTests.cs
@@ -117,4 +117,60 @@ public class StoresServiceTests
         Assert.Null(stores[0].StoreGroupId);
         Assert.Null(result.StoreGroupId);
     }
+
+    // ── SSRF webhook URL validation tests ─────────────────────────────────
+
+    [Theory]
+    [InlineData("http://169.254.169.254/latest/meta-data/")]
+    [InlineData("http://localhost:5021/admin/")]
+    [InlineData("https://evil.com/steal")]
+    [InlineData("http://discord.com/api/webhooks/123/abc")]  // http not https
+    [InlineData("ftp://discord.com/api/webhooks/123/abc")]
+    [InlineData("not-a-url")]
+    public async Task UpdateAsync_WithInvalidDiscordWebhookUrl_ThrowsArgumentException(string badUrl)
+    {
+        var store = new Store { Id = 1, StoreName = "Shop" };
+        var svc = Build([store]);
+        var dto = new UpdateStoreDto("Shop", 10m, DiscordWebhookUrl: badUrl);
+
+        await Assert.ThrowsAsync<ArgumentException>(() => svc.UpdateAsync(1, dto));
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithValidDiscordWebhookUrl_Succeeds()
+    {
+        var store = new Store { Id = 1, StoreName = "Shop", Slug = "shop" };
+        var svc = Build([store]);
+        var dto = new UpdateStoreDto("Shop", 10m, DiscordWebhookUrl: "https://discord.com/api/webhooks/123/abc");
+
+        var result = await svc.UpdateAsync(1, dto);
+
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithNullWebhookUrl_DoesNotChangeWebhook()
+    {
+        var store = new Store { Id = 1, StoreName = "Shop", Slug = "shop", DiscordWebhookUrl = "https://discord.com/api/webhooks/123/abc" };
+        var svc = Build([store]);
+        var dto = new UpdateStoreDto("Shop", 10m, DiscordWebhookUrl: null);
+
+        var result = await svc.UpdateAsync(1, dto);
+
+        // null means "no change" — no exception thrown, update succeeds
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_WithEmptyWebhookUrl_ClearsWebhook()
+    {
+        var store = new Store { Id = 1, StoreName = "Shop", Slug = "shop", DiscordWebhookUrl = "https://discord.com/api/webhooks/123/abc" };
+        var svc = Build([store]);
+        var dto = new UpdateStoreDto("Shop", 10m, DiscordWebhookUrl: string.Empty);
+
+        var result = await svc.UpdateAsync(1, dto);
+
+        // empty string = clear the webhook — no exception, update succeeds
+        Assert.NotNull(result);
+    }
 }


### PR DESCRIPTION
## Summary
- Validates `DiscordWebhookUrl` in `StoresService.UpdateAsync` — rejects any URL that is not `https://discord.com/*`, throwing `ArgumentException` which the controller converts to HTTP 400
- Adds defence-in-depth check in `DiscordWebhookService.PostEmbedAsync` — the `HttpClient` will never reach a non-Discord host even if an invalid URL somehow exists in the database
- Covers both layers with 14 new xUnit tests (TDD — tests written before implementation)

## Test plan
- [ ] `StoresServiceTests` — 6 new tests: rejects internal IPs, non-discord hosts, HTTP discord URLs; accepts valid `https://discord.com` URL, null (no-change), and empty string (clear)
- [ ] `DiscordWebhookServiceTests` — 5 new tests: `PostTestMessageAsync` does not POST for non-HTTPS or non-discord URLs; valid discord URL still posts correctly
- [ ] All 364 backend tests pass (`dotnet test`)
- [ ] PUT `/api/stores/{id}` with `discordWebhookUrl: "http://169.254.169.254/..."` returns 400
- [ ] PUT `/api/stores/{id}` with `discordWebhookUrl: "https://discord.com/api/webhooks/123/abc"` succeeds

References #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)