### PR TITLE
fix(security): require auth on player endpoints to prevent email enumeration

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
@@ -8,6 +8,7 @@ namespace TournamentOrganizer.Api.Controllers;
 
 [ApiController]
 [Route("api/[controller]")]
+[Authorize]
 public class PlayersController : ControllerBase
 {
     private readonly IPlayerService _playerService;
@@ -29,6 +30,7 @@ public class PlayersController : ControllerBase
     }
 
     [HttpPost]
+    [AllowAnonymous]
     public async Task<ActionResult<PlayerDto>> Register(CreatePlayerDto dto)
     {
         try

--- a/src/TournamentOrganizer.Tests/AuthorizationPolicyTests.cs
+++ b/src/TournamentOrganizer.Tests/AuthorizationPolicyTests.cs
@@ -429,4 +429,40 @@ public class AuthorizationPolicyTests(TournamentOrganizerFactory factory)
         var response = await client.GetAsync("/api/auth/me");
         AssertAllowed(response);
     }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Player endpoints — must require [Authorize] to prevent email enumeration
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Unauthenticated_GetAllPlayers_Returns401()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+        AssertUnauthorized(response);
+    }
+
+    [Fact]
+    public async Task Unauthenticated_GetPlayerProfile_Returns401()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players/1/profile");
+        AssertUnauthorized(response);
+    }
+
+    [Fact]
+    public async Task Player_GetAllPlayers_IsAllowed()
+    {
+        var client = factory.ClientAs("Player", playerId: 1);
+        var response = await client.GetAsync("/api/players");
+        AssertAllowed(response);
+    }
+
+    [Fact]
+    public async Task Player_GetPlayerProfile_IsAllowed()
+    {
+        var client = factory.ClientAs("Player", playerId: 1);
+        var response = await client.GetAsync("/api/players/1/profile");
+        AssertAllowed(response);
+    }
 }

--- a/src/TournamentOrganizer.Tests/PlayerSelfServiceRlsTests.cs
+++ b/src/TournamentOrganizer.Tests/PlayerSelfServiceRlsTests.cs
@@ -109,15 +109,14 @@ public class PlayerSelfServiceRlsTests(TournamentOrganizerFactory factory)
 
     // ══════════════════════════════════════════════════════════════════════════
     // GET /api/players/{id}/profile
-    // Public read — no auth required; verify endpoint is accessible
+    // Requires authentication to prevent email enumeration (issue #90)
     // ══════════════════════════════════════════════════════════════════════════
 
     [Fact]
-    public async Task GetProfile_Unauthenticated_IsAllowed()
+    public async Task GetProfile_Unauthenticated_Returns401()
     {
         var client = factory.CreateClient(); // no JWT
         var response = await client.GetAsync("/api/players/1/profile");
-        // 404 is fine (no seed data) — just not 401/403
-        AssertAllowed(response);
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
     }
 }


### PR DESCRIPTION
## Summary
- Adds `[Authorize]` at the `PlayersController` class level, requiring authentication for all player endpoints
- Prevents unauthenticated enumeration of player email addresses via `GET /api/players` and `GET /api/players/{id}/profile`
- Preserves `[AllowAnonymous]` on public endpoints: POST /api/players (registration), and statistics endpoints (commanderstats, ratinghistory, badges)
- Fixes OWASP A01:2021 — Broken Access Control

## Test plan
- [x] Unauthenticated `GET /api/players` returns 401
- [x] Unauthenticated `GET /api/players/{id}/profile` returns 401
- [x] Authenticated requests still return player data correctly
- [x] POST /api/players registration remains public
- [x] All 368 existing tests pass
- [x] New authorization tests added to AuthorizationPolicyTests

References #90