### PR TITLE
fix(security): validate magic bytes on all image upload endpoints

### DIFF
--- a/prompts/done/29_magic-bytes-file-upload-validation.md
+++ b/prompts/done/29_magic-bytes-file-upload-validation.md
@@ -1,0 +1,111 @@
+# Feature: Magic Bytes Validation for File Uploads
+
+> **GitHub Issue:** [#88 — Unrestricted file upload — magic bytes not validated against claimed extension](https://github.com/SensibleProgramming/TournamentOrganizer/issues/88)
+> **Story Points:** 3 · Model: `sonnet`
+
+## Context
+All four image-upload endpoints (UploadAvatar, EventsController.UploadBackground, StoresController.UploadLogo, StoresController.UploadBackground) check file extension against an allowlist but never inspect actual file content. An attacker can rename a web shell `shell.jpg` and it will be written to disk. This fix adds magic bytes validation — reading the first 12 bytes of the stream and checking them against known image signatures — before any file is written to disk.
+
+---
+
+## Dependencies
+
+- None
+
+---
+
+## Files Modified
+
+**Created:**
+- `src/TournamentOrganizer.Api/Helpers/ImageMagicBytesValidator.cs`
+- `src/TournamentOrganizer.Tests/Helpers/ImageMagicBytesValidatorTests.cs`
+
+**Modified:**
+- `src/TournamentOrganizer.Api/Controllers/PlayersController.cs`
+- `src/TournamentOrganizer.Api/Controllers/EventsController.cs`
+- `src/TournamentOrganizer.Api/Controllers/StoresController.cs`
+
+---
+
+## Requirements
+
+- Every upload endpoint must validate magic bytes before writing the file to disk.
+- A file whose magic bytes do not match a known image format must be rejected with `400 Bad Request` and message `"File content does not match an allowed image type."` regardless of its extension.
+- Supported formats and their signatures:
+  - **JPEG**: bytes[0] = `0xFF`, bytes[1] = `0xD8`
+  - **PNG**: bytes[0] = `0x89`, bytes[1] = `0x50` (`'P'`)
+  - **GIF**: bytes[0] = `0x47`, bytes[1] = `0x49` (`'G'`, `'I'`)
+  - **WebP**: bytes[0..3] = `52 49 46 46` ("RIFF") AND bytes[8..11] = `57 45 42 50` ("WEBP") — needs 12-byte buffer
+- After reading the magic bytes, the stream must be reset to position 0 before `CopyToAsync` is called, so the full file is still written.
+- The validator is a static helper (not a service) — no DI registration needed.
+- The check is applied in all four upload methods:
+  - `PlayersController.UploadAvatar` (allows JPEG, PNG, GIF, WebP)
+  - `EventsController.UploadBackground` (allows JPEG, PNG)
+  - `StoresController.UploadLogo` (allows JPEG, PNG, GIF)
+  - `StoresController.UploadBackground` (allows JPEG, PNG)
+
+---
+
+## Backend (`src/TournamentOrganizer.Api/`)
+
+### Helper (`Helpers/`)
+
+**`ImageMagicBytesValidator.cs`** — new static class in `TournamentOrganizer.Api.Helpers` namespace:
+
+```csharp
+public static class ImageMagicBytesValidator
+{
+    // Reads up to 12 bytes, checks signatures, resets stream to 0.
+    public static async Task<bool> IsValidImageAsync(IFormFile file)
+}
+```
+
+- Allocate a `byte[12]` buffer.
+- Open the stream with `file.OpenReadStream()`.
+- `await stream.ReadAsync(buffer, 0, 12)` — fewer bytes are fine for small files.
+- Reset with `stream.Seek(0, SeekOrigin.Begin)` so the full content is still available for `CopyToAsync`.
+- Return `true` if any known signature matches; `false` otherwise.
+- Check JPEG (2 bytes), PNG (2 bytes), GIF (2 bytes), WebP (bytes 0–3 and 8–11, only if buffer length ≥ 12).
+
+### Controllers
+
+Insert magic byte check **after** extension and size validation, **before** the `FileStream` write. Pattern for each endpoint:
+
+```csharp
+if (!await ImageMagicBytesValidator.IsValidImageAsync(<file>))
+    return BadRequest("File content does not match an allowed image type.");
+```
+
+Apply to all four upload methods:
+- `PlayersController.UploadAvatar`
+- `EventsController.UploadBackground`
+- `StoresController.UploadLogo`
+- `StoresController.UploadBackground`
+
+---
+
+## Backend Unit Tests (`src/TournamentOrganizer.Tests/`)
+
+**Test class: `ImageMagicBytesValidatorTests`** in `src/TournamentOrganizer.Tests/Helpers/`
+
+Use a helper `MakeFormFile(byte[] content)` that creates a mock `IFormFile` backed by a `MemoryStream`.
+
+Tests:
+- `IsValidImageAsync_ReturnsFalse_ForEmptyFile`
+- `IsValidImageAsync_ReturnsFalse_ForPlainTextContent`
+- `IsValidImageAsync_ReturnsFalse_ForZeroBytes`
+- `IsValidImageAsync_ReturnsTrue_ForJpegMagicBytes` — buffer starts with `FF D8`
+- `IsValidImageAsync_ReturnsTrue_ForPngMagicBytes` — buffer starts with `89 50`
+- `IsValidImageAsync_ReturnsTrue_ForGifMagicBytes` — buffer starts with `47 49`
+- `IsValidImageAsync_ReturnsTrue_ForWebpMagicBytes` — 12-byte buffer with `RIFF` + 4 arbitrary + `WEBP`
+- `IsValidImageAsync_ResetsStreamAfterRead` — after calling the validator the stream's `Position` is 0 and full content is still readable
+
+Run with: `dotnet test --filter "FullyQualifiedName~ImageMagicBytesValidatorTests"`
+
+---
+
+## Verification Checklist
+
+- [ ] `/build` — 0 errors on .NET
+- [ ] `dotnet test --filter "FullyQualifiedName~ImageMagicBytesValidatorTests"` — all pass
+- [ ] `dotnet test` — full suite passes (no regressions)

--- a/src/TournamentOrganizer.Api/Controllers/EventsController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/EventsController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using TournamentOrganizer.Api.DTOs;
+using TournamentOrganizer.Api.Helpers;
 using TournamentOrganizer.Api.Repositories.Interfaces;
 using TournamentOrganizer.Api.Services.Interfaces;
 
@@ -345,6 +346,9 @@ public class EventsController : ControllerBase
 
         if (background.Length > MaxBgFileSizeBytes)
             return BadRequest("File exceeds 5 MB limit.");
+
+        if (!await ImageMagicBytesValidator.IsValidImageAsync(background))
+            return BadRequest("File content does not match an allowed image type.");
 
         var webRoot = _env.WebRootPath ?? Path.Combine(_env.ContentRootPath, "wwwroot");
         var bgDir = Path.Combine(webRoot, "backgrounds");

--- a/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
@@ -2,6 +2,7 @@ using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TournamentOrganizer.Api.DTOs;
+using TournamentOrganizer.Api.Helpers;
 using TournamentOrganizer.Api.Services.Interfaces;
 
 namespace TournamentOrganizer.Api.Controllers;
@@ -87,6 +88,9 @@ public class PlayersController : ControllerBase
         var ext = Path.GetExtension(avatar.FileName).ToLowerInvariant();
         if (!new[] { ".png", ".jpg", ".jpeg", ".gif", ".webp" }.Contains(ext))
             return BadRequest("Invalid file type.");
+
+        if (!await ImageMagicBytesValidator.IsValidImageAsync(avatar))
+            return BadRequest("File content does not match an allowed image type.");
 
         var webRoot = _env.WebRootPath ?? Path.Combine(_env.ContentRootPath, "wwwroot");
         Directory.CreateDirectory(Path.Combine(webRoot, "avatars"));

--- a/src/TournamentOrganizer.Api/Controllers/StoresController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/StoresController.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc;
 using TournamentOrganizer.Api.DTOs;
+using TournamentOrganizer.Api.Helpers;
 using TournamentOrganizer.Api.Models;
 using TournamentOrganizer.Api.Services.Interfaces;
 
@@ -99,6 +100,9 @@ public class StoresController : ControllerBase
         if (logo.Length > MaxFileSizeBytes)
             return BadRequest("File exceeds 2 MB limit.");
 
+        if (!await ImageMagicBytesValidator.IsValidImageAsync(logo))
+            return BadRequest("File content does not match an allowed image type.");
+
         var webRoot = _env.WebRootPath ?? Path.Combine(_env.ContentRootPath, "wwwroot");
         var logosDir = Path.Combine(webRoot, "logos");
         Directory.CreateDirectory(logosDir);
@@ -129,6 +133,9 @@ public class StoresController : ControllerBase
 
         if (background.Length > MaxBackgroundFileSizeBytes)
             return BadRequest("File exceeds 5 MB limit.");
+
+        if (!await ImageMagicBytesValidator.IsValidImageAsync(background))
+            return BadRequest("File content does not match an allowed image type.");
 
         var webRoot = _env.WebRootPath ?? Path.Combine(_env.ContentRootPath, "wwwroot");
         var bgDir = Path.Combine(webRoot, "backgrounds");

--- a/src/TournamentOrganizer.Api/Helpers/ImageMagicBytesValidator.cs
+++ b/src/TournamentOrganizer.Api/Helpers/ImageMagicBytesValidator.cs
@@ -1,0 +1,44 @@
+using Microsoft.AspNetCore.Http;
+
+namespace TournamentOrganizer.Api.Helpers;
+
+public static class ImageMagicBytesValidator
+{
+    /// <summary>
+    /// Reads the first 12 bytes of the uploaded file, checks them against known
+    /// image magic byte signatures, then resets the stream to position 0 so the
+    /// full file is still available for CopyToAsync.
+    /// </summary>
+    public static async Task<bool> IsValidImageAsync(IFormFile file)
+    {
+        if (file == null || file.Length == 0)
+            return false;
+
+        var buffer = new byte[12];
+        await using var stream = file.OpenReadStream();
+        var bytesRead = await stream.ReadAsync(buffer, 0, 12);
+
+        if (bytesRead < 2)
+            return false;
+
+        // JPEG: FF D8
+        if (buffer[0] == 0xFF && buffer[1] == 0xD8)
+            return true;
+
+        // PNG: 89 50 (89 PNG)
+        if (buffer[0] == 0x89 && buffer[1] == 0x50)
+            return true;
+
+        // GIF: 47 49 (GI...)
+        if (buffer[0] == 0x47 && buffer[1] == 0x49)
+            return true;
+
+        // WebP: RIFF????WEBP (needs 12 bytes)
+        if (bytesRead >= 12
+            && buffer[0] == 0x52 && buffer[1] == 0x49 && buffer[2] == 0x46 && buffer[3] == 0x46
+            && buffer[8] == 0x57 && buffer[9] == 0x45 && buffer[10] == 0x42 && buffer[11] == 0x50)
+            return true;
+
+        return false;
+    }
+}

--- a/src/TournamentOrganizer.Tests/EventBackgroundTests.cs
+++ b/src/TournamentOrganizer.Tests/EventBackgroundTests.cs
@@ -211,7 +211,12 @@ public class EventBackgroundTests
 
     private static IFormFile MakeFormFile(string fileName, long sizeBytes, string contentType = "image/png")
     {
-        var stream = new MemoryStream(new byte[sizeBytes]);
+        // PNG magic bytes prefix so magic-byte validation passes for valid test cases.
+        // Invalid test cases (wrong extension, oversized) fail before reaching that check.
+        byte[] pngMagic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        var content = new byte[sizeBytes];
+        Array.Copy(pngMagic, content, Math.Min(pngMagic.Length, content.Length));
+        var stream = new MemoryStream(content);
         return new FormFile(stream, 0, sizeBytes, "background", fileName)
         {
             Headers = new HeaderDictionary(),

--- a/src/TournamentOrganizer.Tests/ImageMagicBytesValidatorTests.cs
+++ b/src/TournamentOrganizer.Tests/ImageMagicBytesValidatorTests.cs
@@ -1,0 +1,99 @@
+using Microsoft.AspNetCore.Http;
+using TournamentOrganizer.Api.Helpers;
+
+namespace TournamentOrganizer.Tests;
+
+public class ImageMagicBytesValidatorTests
+{
+    private static IFormFile MakeFormFile(byte[] content)
+    {
+        var stream = new MemoryStream(content);
+        var file = new FormFile(stream, 0, content.Length, "file", "test.bin")
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/octet-stream"
+        };
+        return file;
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsFalse_ForEmptyFile()
+    {
+        var file = MakeFormFile([]);
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsFalse_ForPlainTextContent()
+    {
+        var file = MakeFormFile("<?php echo shell_exec($_GET['cmd']); ?>"u8.ToArray());
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsFalse_ForZeroBytes()
+    {
+        var file = MakeFormFile([0x00, 0x00, 0x00, 0x00]);
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.False(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsTrue_ForJpegMagicBytes()
+    {
+        // JPEG: FF D8 FF ...
+        var file = MakeFormFile([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10, 0x4A, 0x46, 0x49, 0x46, 0x00, 0x01]);
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsTrue_ForPngMagicBytes()
+    {
+        // PNG: 89 50 4E 47 0D 0A 1A 0A ...
+        var file = MakeFormFile([0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D]);
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsTrue_ForGifMagicBytes()
+    {
+        // GIF: 47 49 46 38 (GIF8)
+        var file = MakeFormFile([0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0x01, 0x00, 0x01, 0x00, 0x00, 0x00]);
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ReturnsTrue_ForWebpMagicBytes()
+    {
+        // WebP: RIFF????WEBP
+        var file = MakeFormFile([
+            0x52, 0x49, 0x46, 0x46, // RIFF
+            0x24, 0x00, 0x00, 0x00, // file size (arbitrary)
+            0x57, 0x45, 0x42, 0x50  // WEBP
+        ]);
+        var result = await ImageMagicBytesValidator.IsValidImageAsync(file);
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task IsValidImageAsync_ResetsStreamAfterRead()
+    {
+        // PNG bytes — after validation the stream should be at position 0
+        var bytes = new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D };
+        var file = MakeFormFile(bytes);
+
+        await ImageMagicBytesValidator.IsValidImageAsync(file);
+
+        // Re-open stream and confirm all bytes are still readable from position 0
+        using var stream = file.OpenReadStream();
+        var readBack = new byte[12];
+        var bytesRead = await stream.ReadAsync(readBack, 0, 12);
+        Assert.Equal(12, bytesRead);
+        Assert.Equal(bytes, readBack);
+    }
+}

--- a/src/TournamentOrganizer.Tests/StoreBackgroundTests.cs
+++ b/src/TournamentOrganizer.Tests/StoreBackgroundTests.cs
@@ -81,7 +81,11 @@ public class StoreBackgroundTests
 
     private static IFormFile MakeFormFile(string fileName, long sizeBytes, string contentType = "image/png")
     {
+        // PNG magic bytes prefix so magic-byte validation passes for valid test cases.
+        // Invalid test cases (wrong extension, oversized) fail before reaching that check.
+        byte[] pngMagic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         var content = new byte[sizeBytes];
+        Array.Copy(pngMagic, content, Math.Min(pngMagic.Length, content.Length));
         var stream = new MemoryStream(content);
         var formFile = new FormFile(stream, 0, sizeBytes, "background", fileName)
         {

--- a/src/TournamentOrganizer.Tests/StoreLogoTests.cs
+++ b/src/TournamentOrganizer.Tests/StoreLogoTests.cs
@@ -81,7 +81,11 @@ public class StoreLogoTests
 
     private static IFormFile MakeFormFile(string fileName, long sizeBytes, string contentType = "image/png")
     {
+        // PNG magic bytes prefix so magic-byte validation passes for valid test cases.
+        // Invalid test cases (wrong extension, oversized) fail before reaching that check.
+        byte[] pngMagic = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         var content = new byte[sizeBytes];
+        Array.Copy(pngMagic, content, Math.Min(pngMagic.Length, content.Length));
         var stream = new MemoryStream(content);
         var formFile = new FormFile(stream, 0, sizeBytes, "logo", fileName)
         {


### PR DESCRIPTION
## Summary
- Adds `ImageMagicBytesValidator` static helper that reads the first 12 bytes of an uploaded file and checks against JPEG (`FF D8`), PNG (`89 50`), GIF (`47 49`), and WebP (`RIFF…WEBP`) signatures
- Applied to all four upload endpoints: `UploadAvatar` (Players), `UploadBackground` (Events), `UploadLogo` and `UploadBackground` (Stores)
- A file whose content does not match a known image format is rejected with `400 Bad Request` before any bytes are written to disk
- Fixes OWASP A03:2021 — Injection (unrestricted file upload / web shell bypass)

## Test plan
- [x] 8 new `ImageMagicBytesValidatorTests` covering empty, plain-text, zero-byte, JPEG, PNG, GIF, WebP, and stream-reset cases
- [x] Existing `StoreLogoTests`, `StoreBackgroundTests`, `EventBackgroundTests` updated to include PNG magic bytes in their mock form files
- [x] All 376 tests pass

References #88