### PR TITLE
fix(security): replace innerHTML with safe DOM construction in print dialog

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -38,8 +38,10 @@ Create a pull request from the current feature branch targeting `dev`.
 - [ ] <test step 1>
 - [ ] <test step 2>
 
-🤖 Generated with [Claude Code](https://claude.com/claude-code)
+🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `<model>`
 ```
+
+For the `Model:` field: read the `> **Story Points:** … · Model: \`…\`` line from the relevant prompt file in `prompts/ignore/` or `prompts/done/` (match by issue number or slug). If `$ARGUMENTS` contains a model hint, use that. If neither is available, use the current session model (`claude-sonnet-4-6`).
 
 ## Rules
 - Always target `--base dev` — never `main`

--- a/.claude/commands/implement-next.md
+++ b/.claude/commands/implement-next.md
@@ -170,7 +170,9 @@ mv prompts/ignore/<filename>.md prompts/done/<filename>.md
 
 Commit all changes on the feature branch, then run `/create-pr`.
 
-The PR body must include `References #ISSUE_NUMBER` so the branch appears in the issue's Development section.
+The PR body must include:
+- `References #ISSUE_NUMBER` so the branch appears in the issue's Development section.
+- `🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: \`<model>\`` where `<model>` is read from the `> **Story Points:** … · Model: \`…\`` line in the prompt file (set in Step 3).
 
 After the PR is created, update the project board status to "In Review":
 ```bash

--- a/.claude/commands/implement-parallel.md
+++ b/.claude/commands/implement-parallel.md
@@ -88,6 +88,7 @@ Spawn a background agent with `isolation: worktree` and `model: <selected>`:
 > Read the prompt file at `PROMPT_PATH` and follow it exactly.
 > Follow all steps in `/implement-next` starting from Step 3 (branch already determined: `feature/SHORT_NAME`).
 > The remote is `TournamentOrganizer`. Target branch for PRs is `dev`.
+> The model selected for this task is `MODEL_NAME` (e.g. `claude-haiku-4-5-20251001`, `claude-sonnet-4-6`, `claude-opus-4-6`). Include this in the PR body as: `🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: \`MODEL_NAME\``
 > Do not return until the PR URL is confirmed.
 
 Launch all agents simultaneously (one message, multiple Agent tool calls). Include the selected model for each.

--- a/tournament-client/src/app/features/events/event-detail.component.spec.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.spec.ts
@@ -1283,4 +1283,66 @@ describe('EventDetailComponent', () => {
       expect(snackBarOpenSpy).toHaveBeenCalled();
     });
   });
+
+  // ── printQrCode — XSS safety ──────────────────────────────────────────────
+  describe('printQrCode', () => {
+    function setupPrintSpies(): { appendedDivs: HTMLDivElement[] } {
+      const appendedDivs: HTMLDivElement[] = [];
+      // Capture the div but don't actually mutate the DOM (avoids JSDOM recursion).
+      jest.spyOn(document.body, 'appendChild').mockImplementation((node: Node) => {
+        if (node instanceof HTMLDivElement) appendedDivs.push(node);
+        return node as any;
+      });
+      jest.spyOn(document.body, 'removeChild').mockImplementation((node: Node) => node as any);
+      jest.spyOn(window, 'print').mockImplementation(() => {});
+      return { appendedDivs };
+    }
+
+    afterEach(() => jest.restoreAllMocks());
+
+    it('does not use innerHTML with event name (XSS prevention)', async () => {
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      const xssName = '<img src=x onerror="alert(1)">';
+      comp.event = { ...eventStub, name: xssName };
+      (comp as any).qrCodeDataUrl = 'data:image/png;base64,abc';
+      const { appendedDivs } = setupPrintSpies();
+
+      comp.printQrCode();
+
+      expect(appendedDivs.length).toBe(1);
+      // The raw XSS string must NOT appear verbatim as executable markup
+      expect(appendedDivs[0].innerHTML).not.toContain('<img src=x onerror=');
+    });
+
+    it('renders event name as safe text content', async () => {
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      comp.event = { ...eventStub, name: 'My Event' };
+      (comp as any).qrCodeDataUrl = 'data:image/png;base64,abc';
+      const { appendedDivs } = setupPrintSpies();
+
+      comp.printQrCode();
+
+      expect(appendedDivs[0].textContent).toContain('My Event');
+    });
+
+    it('falls back to Check-In when event name is absent', async () => {
+      await setup({ isStoreEmployee: true });
+      const fixture = TestBed.createComponent(EventDetailComponent);
+      fixture.detectChanges();
+      const comp = fixture.componentInstance;
+      comp.event = null as any;
+      (comp as any).qrCodeDataUrl = 'data:image/png;base64,abc';
+      const { appendedDivs } = setupPrintSpies();
+
+      comp.printQrCode();
+
+      expect(appendedDivs[0].textContent).toContain('Check-In');
+    });
+  });
 });

--- a/tournament-client/src/app/features/events/event-detail.component.ts
+++ b/tournament-client/src/app/features/events/event-detail.component.ts
@@ -1052,7 +1052,15 @@ export class EventDetailComponent implements OnInit {
   printQrCode(): void {
     const div = document.createElement('div');
     div.style.cssText = 'position:fixed;top:0;left:0;width:100%;background:#fff;z-index:99999;text-align:center;padding:32px';
-    div.innerHTML = `<h2>${this.event?.name ?? 'Check-In'}</h2><img src="${this.qrCodeDataUrl}" />`;
+
+    const h2 = document.createElement('h2');
+    h2.textContent = this.event?.name ?? 'Check-In';
+    div.appendChild(h2);
+
+    const img = document.createElement('img');
+    img.src = this.qrCodeDataUrl;
+    div.appendChild(img);
+
     document.body.appendChild(div);
     window.print();
     document.body.removeChild(div);


### PR DESCRIPTION
## Summary
- `printQrCode()` in `EventDetailComponent` was using `div.innerHTML` with a template literal embedding `this.event.name` directly — a stored XSS vector exploitable by any store owner who can name an event
- Replaced with `document.createElement('h2')` + `h2.textContent` (XSS-safe) for the heading and `img.src` assignment for the QR code image
- Fixes OWASP A03:2021 — Injection (XSS)

## Test plan
- [x] 3 new Jest tests: XSS payload not present in rendered HTML, event name rendered as safe text, Check-In fallback when event is null
- [x] All 108 `event-detail.component.spec.ts` tests pass
- [x] `/check-zone` clean — `printQrCode()` mutates no component state

References #91