### PR TITLE
chore: fix all CI build warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ jobs:
   backend:
     name: Backend — build, test, fuzz
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     steps:
       - uses: actions/checkout@v4
 
@@ -28,6 +30,8 @@ jobs:
   frontend:
     name: Frontend — Jest
     runs-on: ubuntu-latest
+    env:
+      FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
     defaults:
       run:
         working-directory: tournament-client

--- a/src/TournamentOrganizer.Api/Repositories/GameRepository.cs
+++ b/src/TournamentOrganizer.Api/Repositories/GameRepository.cs
@@ -82,7 +82,7 @@ public class GameRepository : IGameRepository
     public async Task<List<GameResult>> GetStoreGameResultsAsync(int storeId, DateTime? since)
         => await _db.GameResults
             .Where(gr => gr.Game.Pod.Round.Event.StoreEvent != null
-                      && gr.Game.Pod.Round.Event.StoreEvent.StoreId == storeId)
+                      && gr.Game.Pod.Round.Event.StoreEvent!.StoreId == storeId)
             .Where(gr => since == null || gr.Game.Pod.Round.Event.Date >= since)
             .ToListAsync();
 

--- a/src/TournamentOrganizer.Tests/HeadToHeadTests.cs
+++ b/src/TournamentOrganizer.Tests/HeadToHeadTests.cs
@@ -91,7 +91,7 @@ public class HeadToHeadTests
 
         var result = await svc.GetHeadToHeadAsync(1);
 
-        var bob = result.First(e => e.OpponentId == 2);
+        var bob = result!.First(e => e.OpponentId == 2);
         Assert.Equal(1, bob.Wins);
         Assert.Equal(0, bob.Losses);
         Assert.Equal(1, bob.Games);
@@ -112,7 +112,7 @@ public class HeadToHeadTests
 
         var result = await svc.GetHeadToHeadAsync(1);
 
-        var bob = result.First(e => e.OpponentId == 2);
+        var bob = result!.First(e => e.OpponentId == 2);
         Assert.Equal(1, bob.Wins);
         Assert.Equal(1, bob.Losses);
         Assert.Equal(2, bob.Games);
@@ -128,7 +128,7 @@ public class HeadToHeadTests
 
         var result = await svc.GetHeadToHeadAsync(1);
 
-        Assert.Empty(result);
+        Assert.Empty(result!);
     }
 
     [Fact]
@@ -141,7 +141,7 @@ public class HeadToHeadTests
 
         var result = await svc.GetHeadToHeadAsync(1);
 
-        Assert.Equal(2, result.Count);
+        Assert.Equal(2, result!.Count);
         Assert.Contains(result, e => e.OpponentId == 2);
         Assert.Contains(result, e => e.OpponentId == 3);
     }
@@ -171,7 +171,7 @@ public class HeadToHeadTests
 
         var result = await svc.GetHeadToHeadAsync(1);
 
-        Assert.Equal(3, result[0].OpponentId); // Charlie first (2 games)
-        Assert.Equal(2, result[1].OpponentId); // Bob second (1 game)
+        Assert.Equal(3, result![0].OpponentId); // Charlie first (2 games)
+        Assert.Equal(2, result![1].OpponentId); // Bob second (1 game)
     }
 }

--- a/src/TournamentOrganizer.Tests/LicenseTierServiceTests.cs
+++ b/src/TournamentOrganizer.Tests/LicenseTierServiceTests.cs
@@ -13,7 +13,7 @@ public class LicenseTierServiceTests
         public Task<License?> GetByStoreAsync(int storeId) => Task.FromResult(license);
         public Task<List<License>> GetAllAsync() => Task.FromResult(new List<License>());
         public Task<License> CreateAsync(License l) => Task.FromResult(l);
-        public Task<License?> UpdateAsync(License l) => Task.FromResult(l);
+        public Task<License?> UpdateAsync(License l) => Task.FromResult<License?>(l);
     }
 
     private static LicenseTierService CreateService(License? license)


### PR DESCRIPTION
## Summary
- **CS8602** `GameRepository.cs:85` — added `!` null-forgiving operator after explicit `StoreEvent != null` guard that the compiler couldn't track through EF Core's expression tree
- **CS8602/CS8604** `HeadToHeadTests.cs` — added `!` on `result` references in tests where the player is known to exist (non-null case is the test intent); the `PlayerNotFound` test already asserts `Assert.Null(result)` separately
- **CS8619** `LicenseTierServiceTests.cs:16` — changed `Task.FromResult(l)` to `Task.FromResult<License?>(l)` to match the `Task<License?>` return type on the fake's `UpdateAsync`
- **Node.js 20 deprecation** `ci.yml` — added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to both jobs to opt into Node.js 24 now ahead of the June 2026 forced migration

## Test plan
- [x] `dotnet build --configuration Release` — 0 warnings, 0 errors
- [x] `dotnet test` — 376/376 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`