### PR TITLE
fix(security): validate returnUrl before redirect to prevent open redirect

### DIFF
--- a/tournament-client/src/app/features/auth/oauth-callback.component.spec.ts
+++ b/tournament-client/src/app/features/auth/oauth-callback.component.spec.ts
@@ -170,4 +170,39 @@ describe('OAuthCallbackComponent', () => {
     setup({});
     expect(consoleSpy).toHaveBeenCalledWith('OAuth callback error:', null);
   });
+
+  // ─── Open redirect prevention (returnUrl validation) ──────────────────
+
+  afterEach(() => sessionStorage.clear());
+
+  it('redirects to a valid relative returnUrl from sessionStorage', () => {
+    sessionStorage.setItem('auth_return_url', '/events/42');
+    setup({}, '#token=my-jwt');
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    const [parsedUrl] = navigateSpy.mock.calls[0];
+    // /events/42 should parse to a path with segments ['events', '42']
+    expect(parsedUrl?.path).toEqual(['events', '42']);
+  });
+
+  it('falls back to "/" when returnUrl is an absolute external URL', () => {
+    sessionStorage.setItem('auth_return_url', 'https://evil.com/steal');
+    setup({}, '#token=my-jwt');
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    const [parsedUrl] = navigateSpy.mock.calls[0];
+    expect(isRootPath(parsedUrl)).toBe(true);
+  });
+
+  it('falls back to "/" when returnUrl starts with //', () => {
+    sessionStorage.setItem('auth_return_url', '//evil.com/steal');
+    setup({}, '#token=my-jwt');
+    expect(navigateSpy).toHaveBeenCalledTimes(1);
+    const [parsedUrl] = navigateSpy.mock.calls[0];
+    expect(isRootPath(parsedUrl)).toBe(true);
+  });
+
+  it('removes returnUrl from sessionStorage after redirect', () => {
+    sessionStorage.setItem('auth_return_url', '/events');
+    setup({}, '#token=my-jwt');
+    expect(sessionStorage.getItem('auth_return_url')).toBeNull();
+  });
 });

--- a/tournament-client/src/app/features/auth/oauth-callback.component.ts
+++ b/tournament-client/src/app/features/auth/oauth-callback.component.ts
@@ -33,9 +33,12 @@ export class OAuthCallbackComponent implements OnInit {
       this.authService.storeToken(token);
       // Full page reload so AuthService.loadFromStorage() runs fresh
       // and the toolbar renders with the correct user state from the start.
-      const returnUrl = sessionStorage.getItem('auth_return_url') || '/';
+      const returnUrl = sessionStorage.getItem('auth_return_url') ?? '/';
       sessionStorage.removeItem('auth_return_url');
-      window.location.href = returnUrl;
+      const safeUrl = returnUrl.startsWith('/') && !returnUrl.startsWith('//')
+        ? returnUrl
+        : '/';
+      window.location.href = safeUrl;
     } else {
       console.error('OAuth callback error:', error);
       window.location.href = '/';


### PR DESCRIPTION
## Summary
- `oauth-callback.component.ts` was using the raw `sessionStorage` `auth_return_url` value as `window.location.href` with no validation, allowing an attacker to craft `/login?returnUrl=https://evil.com` and silently redirect victims after OAuth authentication
- Added a safe-path check: `returnUrl` must start with `/` and must not start with `//` (protocol-relative URL); any other value falls back to `/`
- Fixes OWASP A01:2021 — Broken Access Control (Open Redirect)

## Test plan
- [x] Valid relative path (`/events/42`) — redirects correctly
- [x] Absolute external URL (`https://evil.com`) — falls back to `/`
- [x] Protocol-relative URL (`//evil.com`) — falls back to `/`
- [x] `auth_return_url` removed from sessionStorage after redirect
- [x] All 15 `oauth-callback.component.spec.ts` tests pass

References #92

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-haiku-4-5-20251001`