### PR TITLE
fix(security): require authentication for POST /api/players

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
@@ -31,7 +31,6 @@ public class PlayersController : ControllerBase
     }
 
     [HttpPost]
-    [AllowAnonymous]
     public async Task<ActionResult<PlayerDto>> Register(CreatePlayerDto dto)
     {
         try

--- a/src/TournamentOrganizer.Tests/FuzzTests.cs
+++ b/src/TournamentOrganizer.Tests/FuzzTests.cs
@@ -220,10 +220,14 @@ public class FuzzTests
 
         Assert.NotEqual(HttpStatusCode.InternalServerError, response.StatusCode);
 
-        // Response body must be valid JSON
-        var responseBody = await response.Content.ReadAsStringAsync();
-        var exception = Record.Exception(() => JsonDocument.Parse(responseBody));
-        Assert.Null(exception);
+        // 401/403 responses have empty bodies by default — only validate JSON for business responses.
+        if (response.StatusCode != HttpStatusCode.Unauthorized &&
+            response.StatusCode != HttpStatusCode.Forbidden)
+        {
+            var responseBody = await response.Content.ReadAsStringAsync();
+            var exception = Record.Exception(() => JsonDocument.Parse(responseBody));
+            Assert.Null(exception);
+        }
     }
 
     // -----------------------------------------------------------------------

--- a/src/TournamentOrganizer.Tests/PlayerRegistrationAuthTests.cs
+++ b/src/TournamentOrganizer.Tests/PlayerRegistrationAuthTests.cs
@@ -1,0 +1,40 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that POST /api/players requires authentication.
+/// Before the fix the endpoint had [AllowAnonymous], allowing mass account creation
+/// by unauthenticated callers (OWASP A01 — Broken Access Control).
+/// </summary>
+public class PlayerRegistrationAuthTests(TournamentOrganizerFactory factory)
+    : IClassFixture<TournamentOrganizerFactory>
+{
+    [Fact]
+    public async Task Register_Returns401_WhenNoAuthToken()
+    {
+        var client = factory.CreateClient();
+
+        var response = await client.PostAsJsonAsync("/api/players",
+            new { name = "Bot", email = "bot@attacker.com" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_IsAllowed_WhenAuthenticated()
+    {
+        // Any authenticated user (e.g. a store employee) should be permitted
+        // to create a player account — authentication is the only gate.
+        var client = factory.ClientAs("StoreEmployee");
+
+        var response = await client.PostAsJsonAsync("/api/players",
+            new { name = "Valid Player", email = "valid@example.com" });
+
+        Assert.True(
+            response.StatusCode != HttpStatusCode.Unauthorized &&
+            response.StatusCode != HttpStatusCode.Forbidden,
+            $"Expected authenticated request to be allowed, got {(int)response.StatusCode}");
+    }
+}


### PR DESCRIPTION
## Summary

- Removes `[AllowAnonymous]` from `PlayersController.Register()` so the class-level `[Authorize]` applies
- Unauthenticated callers now receive **401 Unauthorized** instead of being able to mass-create player accounts with arbitrary names/emails
- Store managers and authenticated users retain full access — the endpoint still accepts `CreatePlayerDto` from the body
- Updated `FuzzTests.HttpPostPlayer_NeverReturns500` to skip the JSON body assertion on 401/403 responses (ASP.NET Core returns an empty body for those)

## Test plan

- [x] `PlayerRegistrationAuthTests.Register_Returns401_WhenNoAuthToken` — was red (201 Created), now green (401)
- [x] `PlayerRegistrationAuthTests.Register_IsAllowed_WhenAuthenticated` — passes
- [x] `dotnet test` — 380 tests pass
- [x] `dotnet build` — 0 errors
- [x] `ng build` — 0 errors (pre-existing warnings unchanged)

References #96

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`