### PR TITLE
fix(security): add ownership guard to trade suggestions and demand endpoints

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/SuggestedTradeController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/SuggestedTradeController.cs
@@ -1,3 +1,4 @@
+using System.Security.Claims;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using TournamentOrganizer.Api.Services.Interfaces;
@@ -16,6 +17,7 @@ public class SuggestedTradeController : ControllerBase
     [Authorize(Policy = "Tier2Required")]
     public async Task<IActionResult> GetSuggestions(int playerId)
     {
+        if (!OwnsPlayer(playerId)) return Forbid();
         var result = await _service.GetSuggestionsAsync(playerId);
         return Ok(result);
     }
@@ -24,7 +26,15 @@ public class SuggestedTradeController : ControllerBase
     [Authorize(Policy = "Tier2Required")]
     public async Task<IActionResult> GetDemand(int playerId)
     {
+        if (!OwnsPlayer(playerId)) return Forbid();
         var result = await _service.GetDemandAsync(playerId);
         return Ok(result);
+    }
+
+    private bool OwnsPlayer(int playerId)
+    {
+        if (User.HasClaim("role", "Administrator")) return true;
+        var jwtPlayerId = int.TryParse(User.FindFirstValue("playerId"), out var pid) ? pid : 0;
+        return jwtPlayerId == playerId;
     }
 }

--- a/src/TournamentOrganizer.Tests/IdorTradeSuggestionsTests.cs
+++ b/src/TournamentOrganizer.Tests/IdorTradeSuggestionsTests.cs
@@ -1,0 +1,93 @@
+using System.Net;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that GET /api/players/{playerId}/trades/suggestions and
+/// GET /api/players/{playerId}/trades/demand enforce ownership —
+/// a Tier2 player cannot read another player's trade data (IDOR).
+/// OWASP A01:2021 — Broken Access Control.
+/// </summary>
+public class IdorTradeSuggestionsTests(TournamentOrganizerFactory factory)
+    : IClassFixture<TournamentOrganizerFactory>
+{
+    // Player 1 is the caller; player 2 is the victim.
+    private const int OwnPlayerId   = 1;
+    private const int OtherPlayerId = 2;
+
+    // ── /trades/suggestions ──────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetSuggestions_Returns403_WhenTier2PlayerRequestsOtherPlayersData()
+    {
+        var client = factory.ClientAs("Player", playerId: OwnPlayerId, licenseTier: "Tier2");
+
+        var response = await client.GetAsync($"/api/players/{OtherPlayerId}/trades/suggestions");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetSuggestions_IsAllowed_WhenPlayerRequestsOwnData()
+    {
+        var client = factory.ClientAs("Player", playerId: OwnPlayerId, licenseTier: "Tier2");
+
+        var response = await client.GetAsync($"/api/players/{OwnPlayerId}/trades/suggestions");
+
+        Assert.True(
+            response.StatusCode != HttpStatusCode.Unauthorized &&
+            response.StatusCode != HttpStatusCode.Forbidden,
+            $"Expected own data to be accessible, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task GetSuggestions_IsAllowed_WhenAdministratorRequestsAnyPlayersData()
+    {
+        var client = factory.ClientAs("Administrator");
+
+        var response = await client.GetAsync($"/api/players/{OtherPlayerId}/trades/suggestions");
+
+        Assert.True(
+            response.StatusCode != HttpStatusCode.Unauthorized &&
+            response.StatusCode != HttpStatusCode.Forbidden,
+            $"Expected Administrator to access any player's data, got {(int)response.StatusCode}");
+    }
+
+    // ── /trades/demand ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetDemand_Returns403_WhenTier2PlayerRequestsOtherPlayersData()
+    {
+        var client = factory.ClientAs("Player", playerId: OwnPlayerId, licenseTier: "Tier2");
+
+        var response = await client.GetAsync($"/api/players/{OtherPlayerId}/trades/demand");
+
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetDemand_IsAllowed_WhenPlayerRequestsOwnData()
+    {
+        var client = factory.ClientAs("Player", playerId: OwnPlayerId, licenseTier: "Tier2");
+
+        var response = await client.GetAsync($"/api/players/{OwnPlayerId}/trades/demand");
+
+        Assert.True(
+            response.StatusCode != HttpStatusCode.Unauthorized &&
+            response.StatusCode != HttpStatusCode.Forbidden,
+            $"Expected own data to be accessible, got {(int)response.StatusCode}");
+    }
+
+    [Fact]
+    public async Task GetDemand_IsAllowed_WhenAdministratorRequestsAnyPlayersData()
+    {
+        var client = factory.ClientAs("Administrator");
+
+        var response = await client.GetAsync($"/api/players/{OtherPlayerId}/trades/demand");
+
+        Assert.True(
+            response.StatusCode != HttpStatusCode.Unauthorized &&
+            response.StatusCode != HttpStatusCode.Forbidden,
+            $"Expected Administrator to access any player's data, got {(int)response.StatusCode}");
+    }
+}


### PR DESCRIPTION
## Summary

- Adds an `OwnsPlayer(playerId)` helper to `SuggestedTradeController` that checks the JWT `playerId` claim
- Both `GET /api/players/{playerId}/trades/suggestions` and `GET /api/players/{playerId}/trades/demand` now return **403 Forbidden** if the caller's JWT `playerId` does not match the URL parameter
- Administrators bypass the ownership check and retain full access

## Test plan

- [x] `GetSuggestions_Returns403_WhenTier2PlayerRequestsOtherPlayersData` — was red (200 OK), now green
- [x] `GetDemand_Returns403_WhenTier2PlayerRequestsOtherPlayersData` — was red (200 OK), now green
- [x] Own-player and Administrator access still allowed (4 passing tests)
- [x] `dotnet test` — 386 tests pass
- [x] `dotnet build` — 0 errors

References #97

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`