### PR TITLE
fix(security): use Frontend:BaseUrl config for all OAuth error redirects

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/AuthController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/AuthController.cs
@@ -40,16 +40,18 @@ public class AuthController : ControllerBase
     [HttpGet("google-callback")]
     public async Task<IActionResult> GoogleCallback()
     {
+        var frontendBase = _configuration["Frontend:BaseUrl"] ?? "http://localhost:4200";
+
         var result = await HttpContext.AuthenticateAsync(CookieAuthenticationDefaults.AuthenticationScheme);
         if (!result.Succeeded)
-            return Redirect("http://localhost:4200/auth/callback?error=auth_failed");
+            return Redirect($"{frontendBase}/auth/callback?error=auth_failed");
 
         var email    = result.Principal!.FindFirstValue(ClaimTypes.Email);
         var name     = result.Principal.FindFirstValue(ClaimTypes.Name);
         var googleId = result.Principal.FindFirstValue(ClaimTypes.NameIdentifier);
 
         if (email == null || googleId == null)
-            return Redirect("http://localhost:4200/auth/callback?error=missing_claims");
+            return Redirect($"{frontendBase}/auth/callback?error=missing_claims");
 
         var user = await _authService.FindOrCreateUserAsync(email, name ?? email, googleId);
         var token = await _authService.GenerateJwtAsync(user);
@@ -63,7 +65,6 @@ public class AuthController : ControllerBase
             Expires  = refreshToken.ExpiresAt,
         });
 
-        var frontendBase = _configuration["Frontend:BaseUrl"] ?? "http://localhost:4200";
         return Redirect($"{frontendBase}/auth/callback#token={Uri.EscapeDataString(token)}");
     }
 

--- a/src/TournamentOrganizer.Api/appsettings.json
+++ b/src/TournamentOrganizer.Api/appsettings.json
@@ -16,6 +16,9 @@
     "ExpiryMinutes": 60,
     "RefreshTokenExpiryDays": 30
   },
+  "Frontend": {
+    "BaseUrl": "http://localhost:4200"
+  },
   "Google": {
     "ClientId": "REPLACE_WITH_USER_SECRETS",
     "ClientSecret": "REPLACE_WITH_USER_SECRETS"

--- a/src/TournamentOrganizer.Tests/OAuthRedirectConfigTests.cs
+++ b/src/TournamentOrganizer.Tests/OAuthRedirectConfigTests.cs
@@ -1,0 +1,61 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that the OAuth callback does NOT hardcode http://localhost:4200.
+/// The Frontend:BaseUrl config key must be respected for all redirect paths
+/// (success and error). OWASP A02:2021 — Cryptographic Failures.
+/// </summary>
+public class OAuthRedirectConfigTests
+{
+    /// <summary>
+    /// Factory that overrides Frontend:BaseUrl to a custom sentinel value so we
+    /// can detect whether the controller uses config or the hardcoded string.
+    /// </summary>
+    private class CustomFrontendFactory : TournamentOrganizerFactory
+    {
+        internal const string CustomOrigin = "https://custom.example.com";
+
+        protected override void ConfigureWebHost(IWebHostBuilder builder)
+        {
+            base.ConfigureWebHost(builder);
+            builder.ConfigureAppConfiguration((_, cfg) =>
+            {
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Frontend:BaseUrl"] = CustomOrigin,
+                });
+            });
+        }
+    }
+
+    [Fact]
+    public async Task GoogleCallback_ErrorRedirect_UsesConfiguredBaseUrl_NotHardcodedLocalhost()
+    {
+        // Arrange — call the callback without a valid Google auth cookie so it
+        // hits the error path: Redirect("http://localhost:4200/auth/callback?error=auth_failed")
+        using var factory = new CustomFrontendFactory();
+        var client = factory.CreateClient(
+            new Microsoft.AspNetCore.Mvc.Testing.WebApplicationFactoryClientOptions
+            {
+                AllowAutoRedirect = false,   // capture the redirect rather than following it
+            });
+
+        // Act — GET /api/auth/google-callback with no cookie will fail authentication
+        var response = await client.GetAsync("/api/auth/google-callback");
+
+        // Assert — should redirect to the configured origin, NOT http://localhost:4200
+        Assert.True(
+            response.StatusCode == HttpStatusCode.Redirect ||
+            response.StatusCode == HttpStatusCode.Found ||
+            response.StatusCode == HttpStatusCode.MovedPermanently,
+            $"Expected a redirect but got {(int)response.StatusCode}");
+
+        var location = response.Headers.Location?.ToString() ?? "";
+        Assert.Contains(CustomFrontendFactory.CustomOrigin, location);
+        Assert.DoesNotContain("http://localhost:4200", location);
+    }
+}


### PR DESCRIPTION
## Summary

- All three `Redirect(...)` calls in `GoogleCallback` now use `_configuration["Frontend:BaseUrl"]` (default: `http://localhost:4200`) instead of the hardcoded string
- `Frontend:BaseUrl` added to `appsettings.json`; production deployments override via `appsettings.Production.json` or environment variable
- Eliminates the risk of tokens/errors being sent over plaintext HTTP if the API is deployed without updating hardcoded strings

## Test plan

- [x] `GoogleCallback_ErrorRedirect_UsesConfiguredBaseUrl_NotHardcodedLocalhost` — was red (redirected to `http://localhost:4200`), now green
- [x] `dotnet test` — 392 tests pass
- [x] `dotnet build` — 0 errors

References #99

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`