### PR TITLE
fix(security): path traversal guard on RemoveAvatar file deletion

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/PlayersController.cs
@@ -115,7 +115,13 @@ public class PlayersController : ControllerBase
         if (player.AvatarUrl != null)
         {
             var webRoot = _env.WebRootPath ?? Path.Combine(_env.ContentRootPath, "wwwroot");
-            var filePath = Path.Combine(webRoot, player.AvatarUrl.TrimStart('/').Replace('/', Path.DirectorySeparatorChar));
+            var avatarsDir = Path.GetFullPath(Path.Combine(webRoot, "avatars"));
+            var filePath = Path.GetFullPath(Path.Combine(webRoot,
+                player.AvatarUrl.TrimStart('/').Replace('/', Path.DirectorySeparatorChar)));
+
+            if (!filePath.StartsWith(avatarsDir + Path.DirectorySeparatorChar, StringComparison.OrdinalIgnoreCase))
+                return BadRequest("Invalid avatar path.");
+
             if (System.IO.File.Exists(filePath)) System.IO.File.Delete(filePath);
         }
 

--- a/src/TournamentOrganizer.Tests/PlayerAvatarPathTraversalTests.cs
+++ b/src/TournamentOrganizer.Tests/PlayerAvatarPathTraversalTests.cs
@@ -1,0 +1,148 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.FileProviders;
+using TournamentOrganizer.Api.Controllers;
+using TournamentOrganizer.Api.DTOs;
+using TournamentOrganizer.Api.Models;
+using TournamentOrganizer.Api.Services.Interfaces;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// TDD tests for path traversal guard in RemoveAvatar.
+/// Written BEFORE implementation — they fail until the guard is in place.
+/// </summary>
+public class PlayerAvatarPathTraversalTests
+{
+    // ── Fake IPlayerService ──────────────────────────────────────────────
+
+    private sealed class FakePlayerService : IPlayerService
+    {
+        private readonly Player? _player;
+        public bool WasAvatarCleared { get; private set; }
+
+        public FakePlayerService(string? avatarUrl)
+        {
+            _player = new Player { Id = 1, Name = "Alice", Email = "alice@test.com", AvatarUrl = avatarUrl };
+        }
+
+        public Task<Player?> GetByIdAsync(int id)
+            => Task.FromResult(_player);
+
+        public Task<PlayerDto> UpdateAvatarUrlAsync(int id, string? url)
+        {
+            WasAvatarCleared = url == null;
+            var dto = new PlayerDto(1, "Alice", "alice@test.com", 25.0, 8.333, 0.0, false, 5, true, url);
+            return Task.FromResult(dto);
+        }
+
+        public Task<bool> IsPlayerEmailAsync(int id, string? email) => Task.FromResult(true);
+        public Task<bool> IsPlayerAtStoreAsync(int playerId, int storeId) => Task.FromResult(false);
+
+        // No-op stubs for the rest
+        public Task<PlayerDto> RegisterAsync(CreatePlayerDto dto) => throw new NotImplementedException();
+        public Task<List<PlayerDto>> GetAllAsync() => throw new NotImplementedException();
+        public Task<List<LeaderboardEntryDto>> GetLeaderboardAsync() => throw new NotImplementedException();
+        public Task<PlayerDto?> UpdateAsync(int id, UpdatePlayerDto dto) => throw new NotImplementedException();
+        public Task<PlayerProfileDto?> GetProfileAsync(int id) => throw new NotImplementedException();
+        public Task<List<HeadToHeadEntryDto>?> GetHeadToHeadAsync(int playerId) => throw new NotImplementedException();
+        public Task<PlayerCommanderStatsDto?> GetCommanderStatsAsync(int playerId) => throw new NotImplementedException();
+        public Task<RatingHistoryDto?> GetRatingHistoryAsync(int playerId) => throw new NotImplementedException();
+    }
+
+    private sealed class StubBadgeService : IBadgeService
+    {
+        public Task CheckAndAwardAsync(int playerId, BadgeTrigger trigger, int? eventId = null) => Task.CompletedTask;
+        public Task<List<PlayerBadgeDto>> GetBadgesAsync(int playerId) => Task.FromResult(new List<PlayerBadgeDto>());
+    }
+
+    private sealed class FakeWebHostEnvironment : IWebHostEnvironment
+    {
+        public string WebRootPath { get; set; } = "";
+        public string ContentRootPath { get; set; } = Path.GetTempPath();
+        public string EnvironmentName { get; set; } = "Testing";
+        public string ApplicationName { get; set; } = "TournamentOrganizer";
+        public IFileProvider ContentRootFileProvider { get; set; } = null!;
+        public IFileProvider WebRootFileProvider { get; set; } = null!;
+    }
+
+    private static PlayersController BuildController(
+        IPlayerService service,
+        IWebHostEnvironment env)
+    {
+        var controller = new PlayersController(service, env, new StubBadgeService());
+        var claims = new List<Claim>
+        {
+            new(ClaimTypes.Email, "alice@test.com"),
+            new("email", "alice@test.com"),
+            new("role", "Administrator")
+        };
+        controller.ControllerContext = new ControllerContext
+        {
+            HttpContext = new DefaultHttpContext
+            {
+                User = new ClaimsPrincipal(new ClaimsIdentity(claims, "Test"))
+            }
+        };
+        return controller;
+    }
+
+    // ── Tests ────────────────────────────────────────────────────────────
+
+    [Theory]
+    [InlineData("../../appsettings.json")]
+    [InlineData("../../../secret.txt")]
+    [InlineData("avatars/../../appsettings.json")]
+    public async Task RemoveAvatar_TraversalPath_ReturnsBadRequest(string maliciousAvatarUrl)
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(Path.Combine(tempRoot, "avatars"));
+
+        var env = new FakeWebHostEnvironment { WebRootPath = tempRoot };
+        var service = new FakePlayerService(maliciousAvatarUrl);
+        var controller = BuildController(service, env);
+
+        var result = await controller.RemoveAvatar(1);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+
+        Directory.Delete(tempRoot, recursive: true);
+    }
+
+    [Fact]
+    public async Task RemoveAvatar_LegitimateAvatarUrl_DeletesFileAndReturnsOk()
+    {
+        var tempRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        var avatarsDir = Path.Combine(tempRoot, "avatars");
+        Directory.CreateDirectory(avatarsDir);
+
+        var fakeAvatar = Path.Combine(avatarsDir, "1.png");
+        await File.WriteAllBytesAsync(fakeAvatar, [0x89, 0x50]);
+
+        var env = new FakeWebHostEnvironment { WebRootPath = tempRoot };
+        var service = new FakePlayerService("/avatars/1.png");
+        var controller = BuildController(service, env);
+
+        var result = await controller.RemoveAvatar(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+        Assert.False(File.Exists(fakeAvatar), "File should have been deleted");
+        Assert.True(service.WasAvatarCleared);
+
+        Directory.Delete(tempRoot, recursive: true);
+    }
+
+    [Fact]
+    public async Task RemoveAvatar_NullAvatarUrl_ReturnsOkWithoutFileDeletion()
+    {
+        var env = new FakeWebHostEnvironment { WebRootPath = Path.GetTempPath() };
+        var service = new FakePlayerService(null);
+        var controller = BuildController(service, env);
+
+        var result = await controller.RemoveAvatar(1);
+
+        Assert.IsType<OkObjectResult>(result.Result);
+    }
+}


### PR DESCRIPTION
## Summary
- Added path traversal guard to `DELETE /api/players/{id}/avatar` — resolves the file path and asserts it stays within `wwwroot/avatars/` before deleting
- Returns `400 Bad Request` if the resolved path escapes the avatars directory (e.g. `../../appsettings.json`)
- Added `PlayerAvatarPathTraversalTests` with 5 xUnit tests covering traversal payloads and the legitimate deletion path

## Test plan
- [x] 3 traversal payloads return `400 Bad Request`
- [x] Legitimate `/avatars/1.png` deletes the file and returns `200 OK`
- [x] Null `AvatarUrl` skips file deletion and returns `200 OK`
- [x] All 397 backend tests pass
- [x] `dotnet build` — 0 errors

References #100

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-haiku-4-5-20251001`