### PR TITLE
fix(security): validate linkPath to prevent open redirect in notification bell

### DIFF
--- a/tournament-client/src/app/shared/components/notification-bell.component.spec.ts
+++ b/tournament-client/src/app/shared/components/notification-bell.component.spec.ts
@@ -143,4 +143,51 @@ describe('NotificationBellComponent', () => {
 
     expect(mockApiService.markAllNotificationsRead).toHaveBeenCalled();
   });
+
+  describe('onNotifClick — open redirect protection', () => {
+    async function setupAndGetRouter() {
+      await setup(MOCK_USER, true);
+      const fixture = TestBed.createComponent(NotificationBellComponent);
+      fixture.detectChanges();
+      const { Router } = await import('@angular/router');
+      const router = TestBed.inject(Router);
+      const navSpy = jest.spyOn(router, 'navigateByUrl').mockResolvedValue(true);
+      return { fixture, navSpy };
+    }
+
+    it('navigates for a valid relative path starting with /', async () => {
+      const { fixture, navSpy } = await setupAndGetRouter();
+      const notif = makeNotification({ linkPath: '/events/42', isRead: true });
+      fixture.componentInstance.onNotifClick(notif);
+      expect(navSpy).toHaveBeenCalledWith('/events/42');
+    });
+
+    it('does not navigate for a protocol-relative URL (//evil.com)', async () => {
+      const { fixture, navSpy } = await setupAndGetRouter();
+      const notif = makeNotification({ linkPath: '//evil.com', isRead: true });
+      fixture.componentInstance.onNotifClick(notif);
+      expect(navSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate for an absolute https URL', async () => {
+      const { fixture, navSpy } = await setupAndGetRouter();
+      const notif = makeNotification({ linkPath: 'https://phishing.com', isRead: true });
+      fixture.componentInstance.onNotifClick(notif);
+      expect(navSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate for an absolute http URL', async () => {
+      const { fixture, navSpy } = await setupAndGetRouter();
+      const notif = makeNotification({ linkPath: 'http://evil.com', isRead: true });
+      fixture.componentInstance.onNotifClick(notif);
+      expect(navSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not navigate when linkPath is null', async () => {
+      const { fixture, navSpy } = await setupAndGetRouter();
+      const notif = makeNotification({ linkPath: null as any, isRead: true });
+      fixture.componentInstance.onNotifClick(notif);
+      expect(navSpy).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/tournament-client/src/app/shared/components/notification-bell.component.ts
+++ b/tournament-client/src/app/shared/components/notification-bell.component.ts
@@ -131,7 +131,7 @@ export class NotificationBellComponent implements OnInit, OnDestroy {
         },
       });
     }
-    if (n.linkPath) {
+    if (n.linkPath && n.linkPath.startsWith('/') && !n.linkPath.startsWith('//')) {
       this.router.navigateByUrl(n.linkPath);
     }
     this.cdr.detectChanges();


### PR DESCRIPTION
## Summary
- `onNotifClick` was passing `linkPath` from the API response directly to `router.navigateByUrl()` with no validation, allowing protocol-relative (`//evil.com`) or absolute (`https://phishing.com`) URLs to redirect users to attacker-controlled sites
- Adds a guard: only navigate if `linkPath` starts with `/` and not `//`
- Adds 5 unit tests covering: valid relative path, protocol-relative URL, absolute https URL, absolute http URL, and null linkPath

## Test plan
- [ ] Clicking a notification with `linkPath: '/events/1'` navigates correctly
- [ ] Clicking a notification with `linkPath: '//evil.com'` does not navigate
- [ ] Clicking a notification with `linkPath: 'https://phishing.com'` does not navigate
- [ ] All 10 notification-bell unit tests pass

References #103

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-haiku-4-5`