### PR TITLE
fix(security): add X-Content-Type-Options, X-Frame-Options, Referrer-Policy headers

### DIFF
--- a/src/TournamentOrganizer.Api/Program.cs
+++ b/src/TournamentOrganizer.Api/Program.cs
@@ -211,6 +211,15 @@ app.UseStaticFiles(new Microsoft.AspNetCore.Builder.StaticFileOptions
     RequestPath  = "/backgrounds"
 });
 
+// Security response headers — OWASP A05:2021
+app.Use(async (ctx, next) =>
+{
+    ctx.Response.Headers.Append("X-Content-Type-Options", "nosniff");
+    ctx.Response.Headers.Append("X-Frame-Options", "DENY");
+    ctx.Response.Headers.Append("Referrer-Policy", "strict-origin-when-cross-origin");
+    await next();
+});
+
 // Content-Security-Policy header — defence-in-depth against XSS (OWASP A05:2021)
 app.Use(async (ctx, next) =>
 {

--- a/src/TournamentOrganizer.Tests/SecurityResponseHeaderTests.cs
+++ b/src/TournamentOrganizer.Tests/SecurityResponseHeaderTests.cs
@@ -1,0 +1,72 @@
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that security response headers are present on all API responses.
+/// OWASP A05:2021 — Security Misconfiguration.
+/// </summary>
+public class SecurityResponseHeaderTests(TournamentOrganizerFactory factory)
+    : IClassFixture<TournamentOrganizerFactory>
+{
+    [Fact]
+    public async Task ApiResponse_ContainsXContentTypeOptionsHeader()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+
+        Assert.True(
+            response.Headers.Contains("X-Content-Type-Options"),
+            "Expected X-Content-Type-Options response header on every API response.");
+    }
+
+    [Fact]
+    public async Task XContentTypeOptions_IsNosniff()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+
+        var value = response.Headers.GetValues("X-Content-Type-Options").FirstOrDefault() ?? "";
+        Assert.Equal("nosniff", value);
+    }
+
+    [Fact]
+    public async Task ApiResponse_ContainsXFrameOptionsHeader()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+
+        Assert.True(
+            response.Headers.Contains("X-Frame-Options"),
+            "Expected X-Frame-Options response header on every API response.");
+    }
+
+    [Fact]
+    public async Task XFrameOptions_IsDeny()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+
+        var value = response.Headers.GetValues("X-Frame-Options").FirstOrDefault() ?? "";
+        Assert.Equal("DENY", value);
+    }
+
+    [Fact]
+    public async Task ApiResponse_ContainsReferrerPolicyHeader()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+
+        Assert.True(
+            response.Headers.Contains("Referrer-Policy"),
+            "Expected Referrer-Policy response header on every API response.");
+    }
+
+    [Fact]
+    public async Task ReferrerPolicy_IsStrictOriginWhenCrossOrigin()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/players");
+
+        var value = response.Headers.GetValues("Referrer-Policy").FirstOrDefault() ?? "";
+        Assert.Equal("strict-origin-when-cross-origin", value);
+    }
+}


### PR DESCRIPTION
## Summary
- Adds middleware to the ASP.NET Core pipeline setting `X-Content-Type-Options: nosniff` to prevent MIME-sniffing attacks
- Adds `X-Frame-Options: DENY` to block clickjacking via iframe embedding
- Adds `Referrer-Policy: strict-origin-when-cross-origin` to prevent sensitive URL fragments leaking via Referer headers
- Adds 6 xUnit integration tests verifying each header is present with the correct value

## Test plan
- [ ] `dotnet test --filter SecurityResponseHeaderTests` — all 6 tests pass
- [ ] `dotnet build` — 0 errors
- [ ] Confirm headers appear in browser DevTools on any API call

References #105

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`