### PR TITLE
fix(security): environment-gated global exception handler with ErrorController

### DIFF
--- a/prompts/done/28_global-exception-handler.md
+++ b/prompts/done/28_global-exception-handler.md
@@ -1,0 +1,107 @@
+# Feature: Environment-Gated Global Exception Handler
+
+> **GitHub Issue:** [#108 — [Security][LOW] No global exception handler — stack traces exposed if environment misconfigured](https://github.com/SensibleProgramming/TournamentOrganizer/issues/108)
+> **Story Points:** 3 · Model: `claude-sonnet-4-6`
+
+## Context
+
+`Program.cs` currently has an unconditional inline `UseExceptionHandler` lambda that returns a safe JSON error for all environments. However, it does not call `UseDeveloperExceptionPage()` in Development (losing helpful debug output during local development), and it uses an inline lambda rather than the recommended route-based `UseExceptionHandler("/error")` + `ErrorController` pattern. This task replaces the inline lambda with the proper environment-gated pattern.
+
+---
+
+## Dependencies
+
+- None
+
+---
+
+## Files Modified
+
+**Created:**
+- `src/TournamentOrganizer.Api/Controllers/ErrorController.cs` (new)
+- `src/TournamentOrganizer.Tests/GlobalExceptionHandlerTests.cs` (new)
+
+**Modified:**
+- `src/TournamentOrganizer.Api/Program.cs`
+
+---
+
+## Requirements
+
+- In Development, call `app.UseDeveloperExceptionPage()` so the full stack trace is shown locally.
+- In non-Development, call `app.UseExceptionHandler("/error")` which routes to `ErrorController.HandleError`.
+- `ErrorController` is decorated `[ApiController]`, `[ApiExplorerSettings(IgnoreApi = true)]`, listens on `[Route("/error")]`, and returns `Problem(title: "An unexpected error occurred.", statusCode: 500)`.
+- Unhandled exceptions in Production/Staging must return HTTP 500 with a ProblemDetails JSON body — never a raw stack trace.
+- The existing inline lambda (`app.UseExceptionHandler(errorApp => ...)`) must be removed.
+
+---
+
+## Backend (`src/TournamentOrganizer.Api/`)
+
+### Controller (`Controllers/`)
+
+New file `ErrorController.cs`:
+
+```csharp
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+public class ErrorController : ControllerBase
+{
+    [Route("/error")]
+    public IActionResult HandleError() =>
+        Problem(title: "An unexpected error occurred.", statusCode: 500);
+}
+```
+
+### Program.cs change
+
+Replace the existing unconditional block:
+```csharp
+app.UseExceptionHandler(errorApp => errorApp.Run(async ctx =>
+{
+    ctx.Response.StatusCode = 500;
+    ctx.Response.ContentType = "application/json";
+    await ctx.Response.WriteAsJsonAsync(new { error = "An unexpected error occurred." });
+}));
+```
+
+With:
+```csharp
+if (app.Environment.IsDevelopment())
+{
+    app.UseDeveloperExceptionPage();
+}
+else
+{
+    app.UseExceptionHandler("/error");
+}
+```
+
+---
+
+## Backend Unit Tests (`src/TournamentOrganizer.Tests/`)
+
+**Test class: `GlobalExceptionHandlerTests`**
+
+Use `WebApplicationFactory<Program>` with `UseEnvironment("Production")` (same pattern as `CorsEnvironmentGatingTests`).
+
+- `Production_UnhandledException_Returns500WithProblemDetails`
+  — Force an exception by calling an endpoint that throws (use a test-only route or mock a service to throw). Verify response is HTTP 500 and body contains ProblemDetails shape (`"title"`, `"status": 500`).
+- `Production_UnhandledException_DoesNotLeakStackTrace`
+  — Same setup; assert the response body does NOT contain "at " (stack frame prefix) or "Exception" string.
+- `Development_UnhandledException_ReturnsDeveloperExceptionPage`
+  — Use `UseEnvironment("Development")`. Trigger an exception. Verify the response contains a developer-friendly error page (status 500 or developer exception page HTML/text).
+
+**Note:** To trigger an unhandled exception in tests, create a minimal test route or mock a controller action. Alternatively, rely on a dedicated `/api/test-error` endpoint added only in Development, or use the existing `/error` route directly to verify the `ErrorController` returns ProblemDetails.
+
+For simplicity, test the `ErrorController` directly (call `GET /error` and assert ProblemDetails shape) and test that `Program.cs` wires up `UseExceptionHandler("/error")` in Production by checking that an HTTP call to `/error` returns status 500 with ProblemDetails.
+
+Run with: `dotnet test --filter "FullyQualifiedName~GlobalExceptionHandlerTests"`
+
+---
+
+## Verification Checklist
+
+- [ ] `dotnet build src/TournamentOrganizer.Api/` — 0 errors
+- [ ] `dotnet test --filter "FullyQualifiedName~GlobalExceptionHandlerTests"` — all pass
+- [ ] `dotnet test` (full suite) — no regressions in `ExceptionMessageLeakageTests`

--- a/src/TournamentOrganizer.Api/Controllers/ErrorController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/ErrorController.cs
@@ -1,0 +1,12 @@
+using Microsoft.AspNetCore.Mvc;
+
+namespace TournamentOrganizer.Api.Controllers;
+
+[ApiController]
+[ApiExplorerSettings(IgnoreApi = true)]
+public class ErrorController : ControllerBase
+{
+    [Route("/error")]
+    public IActionResult HandleError() =>
+        Problem(title: "An unexpected error occurred.", statusCode: 500);
+}

--- a/src/TournamentOrganizer.Api/Program.cs
+++ b/src/TournamentOrganizer.Api/Program.cs
@@ -167,12 +167,14 @@ builder.Services.AddCors(options =>
 
 var app = builder.Build();
 
-app.UseExceptionHandler(errorApp => errorApp.Run(async ctx =>
+if (app.Environment.IsDevelopment())
 {
-    ctx.Response.StatusCode = 500;
-    ctx.Response.ContentType = "application/json";
-    await ctx.Response.WriteAsJsonAsync(new { error = "An unexpected error occurred." });
-}));
+    app.UseDeveloperExceptionPage();
+}
+else
+{
+    app.UseExceptionHandler("/error");
+}
 
 if (app.Environment.IsDevelopment())
 {

--- a/src/TournamentOrganizer.Tests/GlobalExceptionHandlerTests.cs
+++ b/src/TournamentOrganizer.Tests/GlobalExceptionHandlerTests.cs
@@ -1,0 +1,106 @@
+using System.Net;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using TournamentOrganizer.Api.Data;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that the global exception handler is environment-gated:
+/// Production uses UseExceptionHandler("/error") → ErrorController (ProblemDetails),
+/// Development uses UseDeveloperExceptionPage.
+/// OWASP A05:2021 — Security Misconfiguration.
+/// </summary>
+public class GlobalExceptionHandlerTests
+{
+    private static HttpClient CreateClientForEnvironment(string environment)
+    {
+        var factory = new WebApplicationFactory<Program>()
+            .WithWebHostBuilder(b =>
+            {
+                b.UseEnvironment(environment);
+                b.ConfigureAppConfiguration((_, cfg) =>
+                {
+                    cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                    {
+                        ["Jwt:Key"]                            = TournamentOrganizerFactory.JwtKey,
+                        ["Jwt:Issuer"]                         = TournamentOrganizerFactory.JwtIssuer,
+                        ["Jwt:Audience"]                       = TournamentOrganizerFactory.JwtAudience,
+                        ["Jwt:ExpiryMinutes"]                  = "60",
+                        ["Google:ClientId"]                    = "test-google-client-id",
+                        ["Google:ClientSecret"]                = "test-google-client-secret",
+                        ["ConnectionStrings:DefaultConnection"] = "Server=unused;Database=unused",
+                        ["Cors:AllowedOrigin"]                 = "https://app.example.com",
+                    });
+                });
+                b.ConfigureServices(services =>
+                {
+                    var toRemove = services
+                        .Where(d =>
+                            d.ServiceType == typeof(DbContextOptions<AppDbContext>) ||
+                            d.ServiceType == typeof(DbContextOptions) ||
+                            d.ServiceType == typeof(AppDbContext) ||
+                            d.ServiceType == typeof(IDbContextOptionsConfiguration<AppDbContext>))
+                        .ToList();
+                    foreach (var d in toRemove) services.Remove(d);
+                    services.AddDbContext<AppDbContext>(opts =>
+                        opts.UseInMemoryDatabase("ExceptionHandlerTestsDb_" + environment));
+                });
+            });
+
+        return factory.CreateClient(new WebApplicationFactoryClientOptions
+        {
+            AllowAutoRedirect = false,
+        });
+    }
+
+    /// <summary>
+    /// GET /error in Production must return HTTP 500 with a ProblemDetails JSON body.
+    /// This verifies ErrorController is wired up and returns the correct shape.
+    /// </summary>
+    [Fact]
+    public async Task Production_ErrorRoute_Returns500WithProblemDetails()
+    {
+        var client = CreateClientForEnvironment("Production");
+        var response = await client.GetAsync("/error");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.Contains("\"status\":500", body);
+        Assert.Contains("An unexpected error occurred.", body);
+    }
+
+    /// <summary>
+    /// GET /error in Production must NOT expose internal details (stack traces, exception type names).
+    /// </summary>
+    [Fact]
+    public async Task Production_ErrorRoute_DoesNotLeakInternalDetails()
+    {
+        var client = CreateClientForEnvironment("Production");
+        var response = await client.GetAsync("/error");
+
+        var body = await response.Content.ReadAsStringAsync();
+        Assert.DoesNotContain("Exception", body);
+        Assert.DoesNotContain("   at ", body);
+        Assert.DoesNotContain("StackTrace", body);
+    }
+
+    /// <summary>
+    /// GET /error in Development must also return a safe response (ErrorController still handles it
+    /// in Dev since UseDeveloperExceptionPage only activates on unhandled exceptions, not the /error route).
+    /// Primarily verifies the route exists in both environments.
+    /// </summary>
+    [Fact]
+    public async Task Development_ErrorRoute_Returns500()
+    {
+        var client = CreateClientForEnvironment("Development");
+        var response = await client.GetAsync("/error");
+
+        Assert.Equal(HttpStatusCode.InternalServerError, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- Replaced unconditional inline `UseExceptionHandler` lambda with environment-gated pattern
- Development: `UseDeveloperExceptionPage()` for helpful local debug output
- Production/Staging: `UseExceptionHandler("/error")` routing to new `ErrorController`
- `ErrorController` returns `ProblemDetails` (HTTP 500) — never leaks stack traces

## Test plan
- [x] `Production_ErrorRoute_Returns500WithProblemDetails` — /error returns 500 + ProblemDetails JSON
- [x] `Production_ErrorRoute_DoesNotLeakInternalDetails` — no "Exception" or stack frames in body
- [x] `Development_ErrorRoute_Returns500` — /error still wired in Development
- [x] `ExceptionMessageLeakageTests` — all 4 existing tests still pass (no regressions)
- [x] `dotnet build` — 0 errors
- [x] Angular build — 0 errors

References #108

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`