### PR TITLE
fix(fuzz): enforce email format validation on player create DTO

### DIFF
--- a/src/TournamentOrganizer.Api/DTOs/PlayerDto.cs
+++ b/src/TournamentOrganizer.Api/DTOs/PlayerDto.cs
@@ -1,8 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace TournamentOrganizer.Api.DTOs;
 
 public record PlayerBadgeDto(string BadgeKey, string DisplayName, DateTime AwardedAt, int? EventId);
 
-public record CreatePlayerDto(string Name, string Email);
+public record CreatePlayerDto(
+    string Name,
+    [EmailAddress][MaxLength(254)] string Email
+);
 
 public record UpdatePlayerDto(string Name, string Email, bool IsActive);
 

--- a/src/TournamentOrganizer.Tests/PlayerEmailValidationTests.cs
+++ b/src/TournamentOrganizer.Tests/PlayerEmailValidationTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using System.Net.Http.Json;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that POST /api/players enforces email format validation (RFC 5321).
+/// Invalid email strings must be rejected with HTTP 400 before reaching the service layer.
+/// Found by /fuzz on 2026-03-27.
+/// </summary>
+public class PlayerEmailValidationTests(TournamentOrganizerFactory factory)
+    : IClassFixture<TournamentOrganizerFactory>
+{
+    [Theory]
+    [InlineData("not-an-email")]
+    [InlineData("' OR '1'='1")]
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("../../../etc/passwd")]
+    [InlineData("@nodomain")]
+    [InlineData("missing-at-sign")]
+    public async Task PostPlayer_InvalidEmail_Returns400(string invalidEmail)
+    {
+        var client = factory.ClientAs("Player");
+
+        var response = await client.PostAsJsonAsync("/api/players",
+            new { name = "Test Player", email = invalidEmail });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostPlayer_EmailExceeding254Chars_Returns400()
+    {
+        var client = factory.ClientAs("Player");
+        var longEmail = new string('a', 250) + "@b.com"; // 256 chars
+
+        var response = await client.PostAsJsonAsync("/api/players",
+            new { name = "Test Player", email = longEmail });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task PostPlayer_ValidEmail_Returns201()
+    {
+        var client = factory.ClientAs("Player");
+        var uniqueEmail = $"valid-{Guid.NewGuid()}@example.com";
+
+        var response = await client.PostAsJsonAsync("/api/players",
+            new { name = "Valid Player", email = uniqueEmail });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+    }
+}


### PR DESCRIPTION
## Summary
- Added `[EmailAddress]` and `[MaxLength(254)]` to `CreatePlayerDto.Email` constructor parameter
- `[ApiController]` automatically returns HTTP 400 before the service layer for: SQL injection payloads, XSS strings, path traversal patterns, and malformed email formats
- Valid emails continue to be accepted (201 Created)

## Key detail
Attributes applied to the constructor parameter directly — **not** `[property:]` — because ASP.NET Core MVC record validation requires parameter-level attributes, not property-level.

## Test plan
- [x] `PostPlayer_InvalidEmail_Returns400` (6 cases: SQL injection, XSS, path traversal, `@nodomain`, `missing-at-sign`, `not-an-email`)
- [x] `PostPlayer_EmailExceeding254Chars_Returns400`
- [x] `PostPlayer_ValidEmail_Returns201`
- [x] `ExceptionMessageLeakageTests` — all 4 existing tests still pass (no regressions)
- [x] `dotnet build` — 0 errors
- [x] Angular build — 0 errors

References #116

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`