### PR TITLE
fix(security): restrict AllowedHosts to explicit hostname in Production

### DIFF
--- a/src/TournamentOrganizer.Api/appsettings.Production.json
+++ b/src/TournamentOrganizer.Api/appsettings.Production.json
@@ -1,4 +1,5 @@
 {
+  "AllowedHosts": "api.yourdomain.com",
   "Cors": {
     "AllowedOrigin": "https://app.yourdomain.com"
   }

--- a/src/TournamentOrganizer.Tests/AllowedHostsConfigTests.cs
+++ b/src/TournamentOrganizer.Tests/AllowedHostsConfigTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Configuration;
+
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that AllowedHosts is not a wildcard in Production configuration.
+/// OWASP A05:2021 — Security Misconfiguration.
+/// </summary>
+public class AllowedHostsConfigTests
+{
+    [Fact]
+    public void Production_AllowedHosts_IsNotWildcard()
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "TournamentOrganizer.Api"))
+            .AddJsonFile("appsettings.json", optional: false)
+            .AddJsonFile("appsettings.Production.json", optional: false)
+            .Build();
+
+        var allowedHosts = config["AllowedHosts"];
+
+        Assert.NotNull(allowedHosts);
+        Assert.NotEqual("*", allowedHosts);
+    }
+
+    [Fact]
+    public void Development_AllowedHosts_IsWildcard()
+    {
+        var config = new ConfigurationBuilder()
+            .SetBasePath(Path.Combine(Directory.GetCurrentDirectory(), "..", "..", "..", "..", "TournamentOrganizer.Api"))
+            .AddJsonFile("appsettings.json", optional: false)
+            .Build();
+
+        var allowedHosts = config["AllowedHosts"];
+
+        // Base config keeps wildcard for Development flexibility
+        Assert.Equal("*", allowedHosts);
+    }
+}

--- a/src/TournamentOrganizer.Tests/CorsEnvironmentGatingTests.cs
+++ b/src/TournamentOrganizer.Tests/CorsEnvironmentGatingTests.cs
@@ -32,6 +32,9 @@ public class CorsEnvironmentGatingTests
                         ["Google:ClientId"]                    = "test-google-client-id",
                         ["Google:ClientSecret"]                = "test-google-client-secret",
                         ["ConnectionStrings:DefaultConnection"] = "Server=unused;Database=unused",
+                        // Override AllowedHosts so the in-process test client is not blocked by
+                        // the host-header filtering middleware (appsettings.Production.json restricts this).
+                        ["AllowedHosts"]                       = "*",
                     };
                     foreach (var kv in extraConfig) merged[kv.Key] = kv.Value;
                     cfg.AddInMemoryCollection(merged);

--- a/src/TournamentOrganizer.Tests/GlobalExceptionHandlerTests.cs
+++ b/src/TournamentOrganizer.Tests/GlobalExceptionHandlerTests.cs
@@ -35,6 +35,9 @@ public class GlobalExceptionHandlerTests
                         ["Google:ClientSecret"]                = "test-google-client-secret",
                         ["ConnectionStrings:DefaultConnection"] = "Server=unused;Database=unused",
                         ["Cors:AllowedOrigin"]                 = "https://app.example.com",
+                        // Override AllowedHosts so the in-process test client is not blocked by
+                        // the host-header filtering middleware (appsettings.Production.json restricts this).
+                        ["AllowedHosts"]                       = "*",
                     });
                 });
                 b.ConfigureServices(services =>


### PR DESCRIPTION
## Summary
- Keeps `AllowedHosts: "*"` in base `appsettings.json` (Development flexibility)
- Overrides to `"api.yourdomain.com"` in `appsettings.Production.json` to enable host-header filtering
- Adds config-level tests verifying Production never uses wildcard

## Test plan
- [x] `Production_AllowedHosts_IsNotWildcard` — Production config overrides to specific hostname
- [x] `Development_AllowedHosts_IsWildcard` — base config retains wildcard
- [x] `dotnet build` — 0 errors
- [x] Angular build — 0 errors

References #109

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-haiku-4-5-20251001`