### PR TITLE
fix(security): remove hardcoded Moxfield deck ID and raw HttpClient from DecklistController

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/DecklistController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/DecklistController.cs
@@ -39,41 +39,25 @@ public class DecklistController : ControllerBase
 
         try
         {
-            //var client = _httpFactory.CreateClient("Moxfield");
-            ////var request = new HttpRequestMessage(HttpMethod.Get, $"v2/decks/all/{deckId}");
-            ////request.Headers.Referrer = new Uri($"https://moxfield.com/decks/{deckId}");
-            ////request.Headers.TryAddWithoutValidation("Origin", "https://moxfield.com");
-            //var response = await client.GetAsync($"https://api2.moxfield.com/v2/decks/all/{deckId}");
-            //if (!response.IsSuccessStatusCode) return Ok(Array.Empty<string>());
+            var client = _httpFactory.CreateClient("Moxfield");
+            var response = await client.GetAsync($"https://api2.moxfield.com/v2/decks/all/{deckId}");
+            if (!response.IsSuccessStatusCode) return Ok(Array.Empty<string>());
 
-            //using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
+            using var doc = JsonDocument.Parse(await response.Content.ReadAsStringAsync());
             var commanders = new List<string>();
 
-            //if (doc.RootElement.TryGetProperty("boards", out var boards) &&
-            //    boards.TryGetProperty("commanders", out var commandersBoard) &&
-            //    commandersBoard.TryGetProperty("cards", out var cards))
-            //{
-            //    foreach (var entry in cards.EnumerateObject())
-            //    {
-            //        if (entry.Value.TryGetProperty("card", out var card) &&
-            //            card.TryGetProperty("name", out var name))
-            //        {
-            //            commanders.Add(name.GetString()!);
-            //        }
-            //    }
-            //}
-            using (var client = new HttpClient())
+            if (doc.RootElement.TryGetProperty("boards", out var boards) &&
+                boards.TryGetProperty("commanders", out var commandersBoard) &&
+                commandersBoard.TryGetProperty("cards", out var cards))
             {
-                // Add the User-Agent header
-                client.DefaultRequestHeaders.Add("User-Agent", "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/999.0.9999.999 Safari/537.36");
-
-                // Add other headers as needed (e.g., API key if required)
-                // client.DefaultRequestHeaders.Add("Authorization", "Bearer your-token");
-
-                var response = await client.GetAsync("https://api2.moxfield.com/v2/decks/all/JHjwO92ZUEyNdPzE7D5d7A");
-                response.EnsureSuccessStatusCode();
-                var content = await response.Content.ReadAsStringAsync();
-                // Process content...
+                foreach (var entry in cards.EnumerateObject())
+                {
+                    if (entry.Value.TryGetProperty("card", out var card) &&
+                        card.TryGetProperty("name", out var name))
+                    {
+                        commanders.Add(name.GetString()!);
+                    }
+                }
             }
 
             _cache.Set(cacheKey, commanders, CacheDuration);

--- a/src/TournamentOrganizer.Tests/DecklistDebugRemovalTests.cs
+++ b/src/TournamentOrganizer.Tests/DecklistDebugRemovalTests.cs
@@ -1,0 +1,34 @@
+namespace TournamentOrganizer.Tests;
+
+/// <summary>
+/// Verifies that debug code (hardcoded deck ID, raw HttpClient) has been removed
+/// from DecklistController. OWASP A05:2021 — Security Misconfiguration.
+/// </summary>
+public class DecklistDebugRemovalTests
+{
+    [Fact]
+    public void DecklistController_DoesNotContainHardcodedDeckId()
+    {
+        var controllerPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "..", "..", "..", "..", "TournamentOrganizer.Api",
+            "Controllers", "DecklistController.cs");
+
+        var source = File.ReadAllText(controllerPath);
+
+        Assert.DoesNotContain("JHjwO92ZUEyNdPzE7D5d7A", source);
+    }
+
+    [Fact]
+    public void DecklistController_DoesNotInstantiateRawHttpClient()
+    {
+        var controllerPath = Path.Combine(
+            Directory.GetCurrentDirectory(),
+            "..", "..", "..", "..", "TournamentOrganizer.Api",
+            "Controllers", "DecklistController.cs");
+
+        var source = File.ReadAllText(controllerPath);
+
+        Assert.DoesNotContain("new HttpClient()", source);
+    }
+}


### PR DESCRIPTION
## Summary
- Removed debug block (lines 65–77) that ignored user-supplied URL and always fetched hardcoded deck `JHjwO92ZUEyNdPzE7D5d7A`
- Removed `new HttpClient()` instantiation that bypassed the configured `IHttpClientFactory` named client
- The `Moxfield` named client (already configured in Program.cs with timeouts) is now the only HTTP path

## Test plan
- [x] `DecklistController_DoesNotContainHardcodedDeckId` — source no longer contains the hardcoded ID
- [x] `DecklistController_DoesNotInstantiateRawHttpClient` — source no longer uses `new HttpClient()`
- [x] `dotnet build` — 0 errors
- [x] Angular build — 0 errors

References #110

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-haiku-4-5-20251001`