### PR TITLE
fix(security): restrict GET /api/stores to authenticated callers

### DIFF
--- a/src/TournamentOrganizer.Api/Controllers/StoresController.cs
+++ b/src/TournamentOrganizer.Api/Controllers/StoresController.cs
@@ -34,6 +34,7 @@ public class StoresController : ControllerBase
     }
 
     [HttpGet]
+    [Authorize]
     public async Task<ActionResult<List<StoreDto>>> GetAll()
         => Ok(await _service.GetAllAsync());
 

--- a/src/TournamentOrganizer.Tests/AuthorizationPolicyTests.cs
+++ b/src/TournamentOrganizer.Tests/AuthorizationPolicyTests.cs
@@ -465,4 +465,24 @@ public class AuthorizationPolicyTests(TournamentOrganizerFactory factory)
         var response = await client.GetAsync("/api/players/1/profile");
         AssertAllowed(response);
     }
+
+    // ══════════════════════════════════════════════════════════════════════════
+    // Store list — must not be accessible to anonymous callers (#114)
+    // ══════════════════════════════════════════════════════════════════════════
+
+    [Fact]
+    public async Task Unauthenticated_GetAllStores_Returns401()
+    {
+        var client = factory.CreateClient();
+        var response = await client.GetAsync("/api/stores");
+        AssertUnauthorized(response);
+    }
+
+    [Fact]
+    public async Task Authenticated_GetAllStores_IsAllowed()
+    {
+        var client = factory.ClientAs("Player", playerId: 1);
+        var response = await client.GetAsync("/api/stores");
+        AssertAllowed(response);
+    }
 }


### PR DESCRIPTION
Prevents unauthenticated enumeration of store names, IDs, and subscription tier data from `GET /api/stores`.

The login flow does not require anonymous store listing (login uses Google OAuth only — no store picker), so `[Authorize]` can be applied unconditionally. Any authenticated user (Player, StoreEmployee, StoreManager, Administrator) retains access.

## Changes
- `StoresController.GetAll`: added `[Authorize]` attribute
- `AuthorizationPolicyTests`: added two new tests — `Unauthenticated_GetAllStores_Returns401` and `Authenticated_GetAllStores_IsAllowed`

## Test results
All 435 backend tests pass (2 new tests added).

References #114

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`