### PR TITLE
fix(security): store JWT in-memory only, remove localStorage

### DIFF
--- a/prompts/done/28_jwt-in-memory-storage.md
+++ b/prompts/done/28_jwt-in-memory-storage.md
@@ -1,0 +1,261 @@
+# Feature: JWT In-Memory Storage (Remove localStorage)
+
+> **GitHub Issue:** [#89 — [Security][HIGH] JWT stored in localStorage — accessible to any XSS payload](https://github.com/SensibleProgramming/TournamentOrganizer/issues/89)
+> **Story Points:** 3 · Model: `claude-sonnet-4-6`
+
+## Context
+
+The JWT access token is currently persisted to `localStorage` via `localStorage.setItem('auth_token', token)` in `auth.service.ts`. Any JavaScript executing in the page — including XSS payloads — can read and exfiltrate this token. The backend already issues a `refresh_token` in an `HttpOnly; Secure; SameSite=Strict` cookie on every login and refresh cycle, so the infrastructure to support in-memory session restoration is already in place.
+
+This task implements **Option B** from the issue: store the JWT exclusively in-memory (`BehaviorSubject`) and use the existing `/api/auth/refresh` endpoint (backed by the HttpOnly cookie) to silently restore the session on page reload. No backend changes are required.
+
+---
+
+## Dependencies
+
+- None
+
+---
+
+## Files Modified
+
+**Created:**
+- *(none)*
+
+**Modified:**
+- `tournament-client/src/app/core/services/auth.service.ts`
+- `tournament-client/src/app/core/services/auth.service.spec.ts`
+- `tournament-client/src/app/features/auth/oauth-callback.component.ts`
+- `tournament-client/src/app/features/auth/oauth-callback.component.spec.ts`
+
+---
+
+## Requirements
+
+- JWT must **never** be written to `localStorage` or `sessionStorage`.
+- On construction, `AuthService` silently calls `POST /api/auth/refresh` with `withCredentials: true`. On success it stores the returned JWT in-memory and emits the decoded user. On failure it remains unauthenticated (null user).
+- `storeToken(token)` stores the token in a private `string | null` field and emits the decoded user via `userSubject`. No localStorage writes.
+- `getToken()` returns the in-memory token (with expiry check). No localStorage reads.
+- `logout()` clears the in-memory token and emits null. No localStorage writes.
+- `logoutFull()` revokes the server-side refresh cookie (POST /api/auth/logout) then calls `logout()`.
+- `OAuthCallbackComponent`: after `storeToken()` is called (JWT is now in-memory), navigate using `router.navigate([safeUrl])` instead of `window.location.href`. The full-page reload is no longer required because the in-memory state is already set.
+- All existing `OAuthCallbackComponent` tests must continue to pass (the public API of the component is unchanged; only the internal navigation mechanism changes from `window.location.href` to `Router.navigate`).
+
+---
+
+## Backend (`src/TournamentOrganizer.Api/`)
+
+No backend changes.
+
+---
+
+## Frontend (`tournament-client/src/app/`)
+
+### `core/services/auth.service.ts`
+
+Replace the `localStorage`-based implementation with in-memory storage + silent refresh:
+
+```typescript
+@Injectable({ providedIn: 'root' })
+export class AuthService {
+  private userSubject = new BehaviorSubject<CurrentUser | null>(null);
+  currentUser$ = this.userSubject.asObservable();
+
+  private token: string | null = null;   // in-memory only
+
+  constructor(private http: HttpClient) {
+    this.silentRefresh();
+  }
+
+  private silentRefresh(): void {
+    this.http.post<{ token: string }>(
+      `${environment.apiBase}/api/auth/refresh`,
+      {},
+      { withCredentials: true }
+    ).subscribe({
+      next: res => { this.setToken(res.token); },
+      error: () => {}  // no active session — stay unauthenticated
+    });
+  }
+
+  private setToken(token: string): void {
+    this.token = token;
+    this.userSubject.next(this.decodeJwt(token));
+  }
+
+  storeToken(token: string): void {
+    this.setToken(token);
+  }
+
+  logout(): void {
+    this.token = null;
+    this.userSubject.next(null);
+  }
+
+  logoutFull(): void {
+    this.http.post(`${environment.apiBase}/api/auth/logout`, {}, { withCredentials: true })
+      .subscribe({ error: () => {} });
+    this.logout();
+  }
+
+  getToken(): string | null {
+    if (!this.token) return null;
+    try {
+      const payload = JSON.parse(atob(this.token.split('.')[1]));
+      if (payload.exp && payload.exp * 1000 < Date.now()) {
+        this.token = null;
+        this.userSubject.next(null);
+        return null;
+      }
+    } catch {
+      this.token = null;
+      this.userSubject.next(null);
+      return null;
+    }
+    return this.token;
+  }
+
+  refresh(): Observable<string> {
+    return this.http.post<{ token: string }>(
+      `${environment.apiBase}/api/auth/refresh`,
+      {},
+      { withCredentials: true }
+    ).pipe(
+      tap(res => this.storeToken(res.token)),
+      map(res => res.token)
+    );
+  }
+
+  // ... all getter properties unchanged (currentUser, isStoreEmployee, etc.)
+  // ... login() unchanged
+  // ... decodeJwt() unchanged
+}
+```
+
+### `features/auth/oauth-callback.component.ts`
+
+- Inject `Router` in the constructor.
+- Replace `window.location.href = safeUrl` with `this.router.navigate([safeUrl])`.
+- Replace `window.location.href = '/'` (error path) with `this.router.navigate(['/'])`.
+- Remove the comment about "Full page reload so AuthService.loadFromStorage() runs fresh" — it is no longer needed.
+
+The `readLocationHash()` protected method and all other logic remain unchanged.
+
+---
+
+## Backend Unit Tests
+
+No backend tests required.
+
+---
+
+## Frontend Unit Tests (Jest)
+
+### `core/services/auth.service.spec.ts`
+
+Rewrite the spec to use `HttpClientTestingModule` and `HttpTestingController` for the silent refresh call that happens in the constructor. Remove all `localStorage.setItem/getItem` references — they no longer apply.
+
+**Helpers:**
+- `makeJwt(payload)` — same helper as before
+- `nowSec(offsetSeconds)` — same helper as before
+- `createService(flushWith?: string | 'error')` — configures TestBed with `provideHttpClientTesting()`, creates the service, and optionally flushes the pending refresh request:
+  - `flushWith = 'error'` → `httpController.expectOne(...refresh...).flush('', { status: 401, statusText: 'Unauthorized' })`
+  - `flushWith = <token string>` → `httpController.expectOne(...refresh...).flush({ token: <token> })`
+  - called without argument → does NOT flush (leaves request pending) for tests that verify the pending state
+
+**Describe blocks and test cases:**
+
+`constructor (silentRefresh)`:
+- `emits null immediately before refresh response arrives` — create service without flushing; `currentUser` is null
+- `emits the decoded user when refresh succeeds` — flush with a valid token; `currentUser` matches decoded user
+- `remains null when refresh fails (no active session)` — flush with 401; `currentUser` is null
+- `makes exactly one POST to /api/auth/refresh on construction` — verify via `httpController.expectOne`
+
+`storeToken()`:
+- `emits the decoded CurrentUser on currentUser$`
+- `updates currentUser synchronously`
+- `does NOT write to localStorage`
+
+`logout()`:
+- `clears the in-memory token (getToken returns null)`
+- `emits null on currentUser$`
+- `does NOT touch localStorage`
+
+`getToken()`:
+- `returns null when no token is stored`
+- `returns the token string when valid`
+- `returns null and clears state when token is expired`
+- `returns null and clears state for a malformed token`
+
+`currentUser getter`:
+- `returns null initially`
+- `returns the user set by storeToken`
+- `returns null after logout`
+
+`isStoreEmployee getter`:
+- parameterised — same coverage as before (StoreEmployee, StoreManager, Administrator → true; others → false)
+
+`isStoreManager getter`:
+- parameterised — same as before
+
+`isAdmin getter`:
+- same as before
+
+`login()`:
+- `navigates to the Google OAuth login endpoint via relative URL` — same as before (window.location spy)
+
+`licenseTier / isTier1 / isTier2 getters`:
+- same four cases as before (set up via `storeToken` not localStorage)
+
+Run with: `npx jest --config jest.config.js --testPathPatterns=auth.service`
+
+### `features/auth/oauth-callback.component.spec.ts`
+
+Update tests to replace the `navigateSpy` (which spied on `window.location._locationObjectSetterNavigate`) with a `RouterSpy`:
+
+```typescript
+import { Router } from '@angular/router';
+// In providers: provideRouter([])
+// Spy: jest.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true)
+```
+
+All existing `it(...)` descriptions remain exactly the same. Only the spy setup changes:
+- Replace `navigateSpy` (impl-based) with `routerNavigateSpy` = `jest.spyOn(TestBed.inject(Router), 'navigate')`
+- Replace `navigateSpy` assertions with `routerNavigateSpy`:
+  - `expect(routerNavigateSpy).toHaveBeenCalledWith(['/'])` for root redirects
+  - `expect(routerNavigateSpy).toHaveBeenCalledWith(['/events/42'])` for the returnUrl test
+
+Run with: `npx jest --config jest.config.js --testPathPatterns=oauth-callback`
+
+---
+
+## Verification Checklist
+
+- [ ] `dotnet build src/TournamentOrganizer.Api/` — 0 errors (no backend changes, sanity check)
+- [ ] `cd tournament-client && npx ng build && cd ..` — 0 errors
+- [ ] `npx jest --config jest.config.js --testPathPatterns=auth.service` — all pass
+- [ ] `npx jest --config jest.config.js --testPathPatterns=oauth-callback` — all pass
+- [ ] No `localStorage.getItem\|setItem\|removeItem.*auth_token` in any `.ts` file (grep to confirm)
+
+---
+## Prompt Refinement Suggestions
+
+### Token Efficiency
+- The `auth.service.ts` code block uses `// ... all getter properties unchanged` — this is fine as a signal to keep those methods, but make sure the implementer knows to keep ALL existing getter properties (`currentUser`, `isStoreEmployee`, `isStoreManager`, `isAdmin`, `licenseTier`, `isTier1`, `isTier2`, `isTier3`) and `login()` / `decodeJwt()` verbatim. Consider adding an explicit list to avoid accidental omission.
+- The prompt doesn't mention `auth.interceptor.ts` — add a one-liner confirming it requires no changes (`getToken()` public API is unchanged; reading from memory vs localStorage is an internal detail).
+
+### Anticipated Questions (pre-answer these to skip back-and-forth)
+- Q: Must `createService()` in the spec flush the constructor's silentRefresh call before every test, or only in some tests? → **Every test** that uses `createService()` must flush or error the pending refresh request. Failing to do so causes `httpController.verify()` failures. The `flushWith` parameter on `createService()` should be mandatory (not optional) in practice — only the "emits null before refresh arrives" test legitimately leaves it unflushed and must NOT call `httpController.verify()`.
+- Q: Should `httpController.verify()` be called in `afterEach`? → Yes. Add `afterEach(() => httpController.verify())` to catch unexpected extra requests. Tests that intentionally leave the request pending (the "null before refresh arrives" case) must call `httpController.expectOne(...)` to consume the request manually before the afterEach runs, or skip verify for that test.
+- Q: Does `oauth-callback.component.spec.ts` still need the `navigateSpy` (window impl spy) in `beforeEach`/`afterEach`? → **No.** Once the component uses `this.router.navigate()` instead of `window.location.href`, the `_locationObjectSetterNavigate` spy can be removed entirely from `beforeEach`/`afterEach`. The `replaceStateSpy` (for `history.replaceState`) is still needed — the component still clears the hash fragment.
+- Q: Does `oauth-callback.component.spec.ts` need `AuthService` to be mocked differently now that AuthService makes HTTP calls in its constructor? → No. The spec provides `{ provide: AuthService, useValue: mockAuthService }` — Angular never constructs the real AuthService, so no HTTP calls occur in those tests.
+- Q: Does `router.navigate([safeUrl])` work when `safeUrl` is `/events/42` (starts with '/')? → Yes. Angular Router treats strings starting with '/' as absolute paths.
+
+### Missing Context
+- The `provideHttpClient()` provider must be added alongside `provideHttpClientTesting()` in `auth.service.spec.ts`. Without `provideHttpClient()`, Angular will throw because `HttpClient` is not provided. The correct pair is: `providers: [provideHttpClient(), provideHttpClientTesting()]`.
+- The `HttpTestingController` instance must be retrieved via `TestBed.inject(HttpTestingController)` after `TestBed.configureTestingModule(...)` and before `createService()`. The prompt describes the helper but doesn't show where `httpController` is captured.
+- The "does NOT write to localStorage" test approach is not specified — use `jest.spyOn(localStorage, 'setItem')` and assert `not.toHaveBeenCalledWith('auth_token', expect.any(String))`. The spy must be set up before calling `storeToken()`.
+
+### Optimized Prompt additions (apply inline)
+> Add to Requirements: "The `auth.interceptor.ts` file requires no changes — `getToken()`'s public signature is unchanged."
+> Add to auth.service.spec.ts section: "Add `afterEach(() => httpController.verify())`. For the 'emits null immediately before refresh arrives' test, consume the pending request manually: `httpController.expectOne(url => url.includes('/api/auth/refresh')).flush('', { status: 503, statusText: '' })` at the end of the test body, so verify() passes."

--- a/tournament-client/src/app/core/services/auth.service.spec.ts
+++ b/tournament-client/src/app/core/services/auth.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting, HttpTestingController } from '@angular/common/http/testing';
 import { AuthService } from './auth.service';
 
 // ─── JWT helpers ─────────────────────────────────────────────────────────────
 
 /** Build a minimal JWT with the given payload (header + body + stub signature). */
 function makeJwt(payload: Record<string, unknown>): string {
-  const header  = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
-  const body    = btoa(JSON.stringify(payload));
+  const header = btoa(JSON.stringify({ alg: 'HS256', typ: 'JWT' }));
+  const body   = btoa(JSON.stringify(payload));
   return `${header}.${body}.stub-signature`;
 }
 
@@ -16,7 +18,6 @@ function nowSec(offsetSeconds = 0): number {
 }
 
 // ─── window.location.href mock (login() navigation) ──────────────────────────
-// Uses the Symbol(impl) pattern — see MEMORY.md for explanation.
 
 function getLocationImpl(): any {
   const sym = Object.getOwnPropertySymbols(window.location)
@@ -38,77 +39,83 @@ afterEach(() => {
 
 // ─── Suite ───────────────────────────────────────────────────────────────────
 
-describe('AuthService', () => {
-  beforeEach(() => localStorage.clear());
-  afterEach(() => localStorage.clear());
+const REFRESH_URL = '/api/auth/refresh';
 
-  /** Create a fresh service instance (constructor runs after localStorage is set up). */
-  function createService(): AuthService {
-    TestBed.configureTestingModule({});
-    return TestBed.inject(AuthService);
+describe('AuthService', () => {
+  let httpController: HttpTestingController;
+
+  /**
+   * Create a fresh service instance.
+   * Always flushes (or errors) the constructor's silentRefresh request.
+   *   flushWith = 'error'       → 401 response (no active session)
+   *   flushWith = <token>       → 200 response with { token }
+   *   flushWith = 'pending'     → does NOT flush; request stays pending
+   */
+  function createService(flushWith: string | 'error' | 'pending' = 'error'): AuthService {
+    TestBed.configureTestingModule({
+      providers: [provideHttpClient(), provideHttpClientTesting()],
+    });
+    httpController = TestBed.inject(HttpTestingController);
+    const service = TestBed.inject(AuthService);
+
+    if (flushWith !== 'pending') {
+      const req = httpController.expectOne(r => r.url.includes(REFRESH_URL));
+      if (flushWith === 'error') {
+        req.flush('', { status: 401, statusText: 'Unauthorized' });
+      } else {
+        req.flush({ token: flushWith });
+      }
+    }
+
+    return service;
   }
 
-  // ─── Constructor / loadFromStorage ──────────────────────────────────────
+  afterEach(() => {
+    // Consume any remaining pending requests so verify() doesn't complain
+    // in tests that use flushWith='pending'.
+    httpController?.match(r => r.url.includes(REFRESH_URL));
+    httpController?.verify();
+  });
 
-  describe('constructor (loadFromStorage)', () => {
-    it('emits null when no token in localStorage', () => {
-      const service = createService();
+  // ─── Constructor / silentRefresh ──────────────────────────────────────
+
+  describe('constructor (silentRefresh)', () => {
+    it('emits null immediately before refresh response arrives', () => {
+      const service = createService('pending');
       expect(service.currentUser).toBeNull();
     });
 
-    it('emits the decoded user when a valid token is stored', () => {
+    it('emits the decoded user when refresh succeeds', () => {
       const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService(token);
       expect(service.currentUser).toEqual({
         id: 1, email: 'a@b.com', name: 'Alice', role: 'User',
-        playerId: undefined, storeId: undefined,
+        playerId: undefined, storeId: undefined, licenseTier: undefined,
       });
     });
 
-    it('maps numeric playerId and storeId from JWT claims', () => {
-      const token = makeJwt({ sub: '5', email: 'b@c.com', name: 'Bob', role: 'StoreEmployee', playerId: '3', storeId: '7' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
-      expect(service.currentUser?.playerId).toBe(3);
-      expect(service.currentUser?.storeId).toBe(7);
-    });
-
-    it('removes an expired token and emits null', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(-3600) });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+    it('remains null when refresh fails (no active session)', () => {
+      const service = createService('error');
       expect(service.currentUser).toBeNull();
-      expect(localStorage.getItem('auth_token')).toBeNull();
     });
 
-    it('accepts a token with no exp claim', () => {
-      const token = makeJwt({ sub: '2', email: 'c@d.com', name: 'Carol', role: 'User' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
-      expect(service.currentUser?.name).toBe('Carol');
-    });
-
-    it('removes a malformed token and emits null', () => {
-      localStorage.setItem('auth_token', 'not-a-jwt');
-      const service = createService();
-      expect(service.currentUser).toBeNull();
-      expect(localStorage.getItem('auth_token')).toBeNull();
+    it('makes exactly one POST to /api/auth/refresh on construction', () => {
+      TestBed.configureTestingModule({
+        providers: [provideHttpClient(), provideHttpClientTesting()],
+      });
+      httpController = TestBed.inject(HttpTestingController);
+      TestBed.inject(AuthService);
+      const reqs = httpController.match(r => r.url.includes(REFRESH_URL));
+      expect(reqs.length).toBe(1);
+      expect(reqs[0].request.method).toBe('POST');
     });
   });
 
   // ─── storeToken ─────────────────────────────────────────────────────────
 
   describe('storeToken()', () => {
-    it('saves the token to localStorage', () => {
-      const service = createService();
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
-      service.storeToken(token);
-      expect(localStorage.getItem('auth_token')).toBe(token);
-    });
-
     it('emits the decoded CurrentUser on currentUser$', () => {
-      const service = createService();
+      const service = createService('error');
       const token = makeJwt({ sub: '10', email: 'x@y.com', name: 'Xavier', role: 'Administrator' });
       const emitted: any[] = [];
       service.currentUser$.subscribe(u => emitted.push(u));
@@ -119,72 +126,87 @@ describe('AuthService', () => {
     });
 
     it('updates currentUser synchronously', () => {
-      const service = createService();
+      const service = createService('error');
       const token = makeJwt({ sub: '3', email: 'z@z.com', name: 'Zara', role: 'StoreManager' });
       service.storeToken(token);
       expect(service.currentUser?.name).toBe('Zara');
+    });
+
+    it('does NOT write to localStorage', () => {
+      const service = createService('error');
+      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
+
+      service.storeToken(token);
+
+      expect(localStorage.getItem('auth_token')).toBeNull();
     });
   });
 
   // ─── logout ─────────────────────────────────────────────────────────────
 
   describe('logout()', () => {
-    it('removes the token from localStorage', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
-
+    it('clears the in-memory token (getToken returns null)', () => {
+      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(3600) });
+      const service = createService(token);
       service.logout();
-
-      expect(localStorage.getItem('auth_token')).toBeNull();
+      expect(service.getToken()).toBeNull();
     });
 
     it('emits null on currentUser$', () => {
       const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService(token);
+      service.logout();
+      expect(service.currentUser).toBeNull();
+    });
+
+    it('does NOT touch localStorage', () => {
+      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
+      const service = createService(token);
+      // Confirm logout doesn't write to or corrupt localStorage
+      localStorage.setItem('unrelated_key', 'some-value');
 
       service.logout();
 
-      expect(service.currentUser).toBeNull();
+      // auth_token was never written, unrelated key untouched
+      expect(localStorage.getItem('auth_token')).toBeNull();
+      expect(localStorage.getItem('unrelated_key')).toBe('some-value');
     });
   });
 
   // ─── getToken ───────────────────────────────────────────────────────────
 
   describe('getToken()', () => {
-    it('returns null when no token in localStorage', () => {
-      expect(createService().getToken()).toBeNull();
+    it('returns null when no token is stored', () => {
+      expect(createService('error').getToken()).toBeNull();
     });
 
     it('returns the token string when valid', () => {
       const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(3600) });
-      localStorage.setItem('auth_token', token);
-      expect(createService().getToken()).toBe(token);
+      const service = createService(token);
+      expect(service.getToken()).toBe(token);
     });
 
     it('returns null and clears state when token is expired', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(-3600) });
-      // loadFromStorage removes it, so storeToken directly for this edge case
-      const service = createService();
-      // Bypass loadFromStorage by directly writing to storage after init
-      localStorage.setItem('auth_token', token);
+      const validToken = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(3600) });
+      const service = createService(validToken);
+      // Directly overwrite in-memory token with an expired one (bypassing expiry check in storeToken)
+      const expiredToken = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(-3600) });
+      (service as any).token = expiredToken;
 
       const result = service.getToken();
 
       expect(result).toBeNull();
-      expect(localStorage.getItem('auth_token')).toBeNull();
       expect(service.currentUser).toBeNull();
     });
 
     it('returns null and clears state for a malformed token', () => {
-      const service = createService();
-      localStorage.setItem('auth_token', 'bad.token.here');
+      const validToken = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User', exp: nowSec(3600) });
+      const service = createService(validToken);
+      (service as any).token = 'bad.token.here';
 
       const result = service.getToken();
 
       expect(result).toBeNull();
-      expect(localStorage.getItem('auth_token')).toBeNull();
       expect(service.currentUser).toBeNull();
     });
   });
@@ -192,12 +214,12 @@ describe('AuthService', () => {
   // ─── currentUser getter ──────────────────────────────────────────────────
 
   describe('currentUser getter', () => {
-    it('returns null initially with no token', () => {
-      expect(createService().currentUser).toBeNull();
+    it('returns null initially with no active session', () => {
+      expect(createService('error').currentUser).toBeNull();
     });
 
     it('returns the user set by storeToken', () => {
-      const service = createService();
+      const service = createService('error');
       const token = makeJwt({ sub: '2', email: 'b@c.com', name: 'Bob', role: 'User' });
       service.storeToken(token);
       expect(service.currentUser?.email).toBe('b@c.com');
@@ -205,8 +227,7 @@ describe('AuthService', () => {
 
     it('returns null after logout', () => {
       const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'Alice', role: 'User' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService(token);
       service.logout();
       expect(service.currentUser).toBeNull();
     });
@@ -218,23 +239,23 @@ describe('AuthService', () => {
     it.each(['StoreEmployee', 'StoreManager', 'Administrator'])(
       'returns true for role "%s"',
       (role) => {
-        const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role });
-        localStorage.setItem('auth_token', token);
-        expect(createService().isStoreEmployee).toBe(true);
+        const service = createService('error');
+        service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role }));
+        expect(service.isStoreEmployee).toBe(true);
       }
     );
 
     it.each(['User', 'Player'])(
       'returns false for role "%s"',
       (role) => {
-        const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role });
-        localStorage.setItem('auth_token', token);
-        expect(createService().isStoreEmployee).toBe(false);
+        const service = createService('error');
+        service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role }));
+        expect(service.isStoreEmployee).toBe(false);
       }
     );
 
     it('returns false when no user is logged in', () => {
-      expect(createService().isStoreEmployee).toBe(false);
+      expect(createService('error').isStoreEmployee).toBe(false);
     });
   });
 
@@ -244,23 +265,23 @@ describe('AuthService', () => {
     it.each(['StoreManager', 'Administrator'])(
       'returns true for role "%s"',
       (role) => {
-        const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role });
-        localStorage.setItem('auth_token', token);
-        expect(createService().isStoreManager).toBe(true);
+        const service = createService('error');
+        service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role }));
+        expect(service.isStoreManager).toBe(true);
       }
     );
 
     it.each(['StoreEmployee', 'User'])(
       'returns false for role "%s"',
       (role) => {
-        const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role });
-        localStorage.setItem('auth_token', token);
-        expect(createService().isStoreManager).toBe(false);
+        const service = createService('error');
+        service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role }));
+        expect(service.isStoreManager).toBe(false);
       }
     );
 
     it('returns false when no user is logged in', () => {
-      expect(createService().isStoreManager).toBe(false);
+      expect(createService('error').isStoreManager).toBe(false);
     });
   });
 
@@ -268,22 +289,22 @@ describe('AuthService', () => {
 
   describe('isAdmin getter', () => {
     it('returns true for role "Administrator"', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'Administrator' });
-      localStorage.setItem('auth_token', token);
-      expect(createService().isAdmin).toBe(true);
+      const service = createService('error');
+      service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'Administrator' }));
+      expect(service.isAdmin).toBe(true);
     });
 
     it.each(['StoreManager', 'StoreEmployee', 'User'])(
       'returns false for role "%s"',
       (role) => {
-        const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role });
-        localStorage.setItem('auth_token', token);
-        expect(createService().isAdmin).toBe(false);
+        const service = createService('error');
+        service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role }));
+        expect(service.isAdmin).toBe(false);
       }
     );
 
     it('returns false when no user is logged in', () => {
-      expect(createService().isAdmin).toBe(false);
+      expect(createService('error').isAdmin).toBe(false);
     });
   });
 
@@ -291,11 +312,8 @@ describe('AuthService', () => {
 
   describe('login()', () => {
     it('navigates to the Google OAuth login endpoint via relative URL (proxied in dev)', () => {
-      createService().login();
+      createService('error').login();
       expect(navigateSpy).toHaveBeenCalledTimes(1);
-      // With apiBase = '' the URL is relative: /api/auth/google-login
-      // JSDOM parses a relative path keeping the existing host (localhost from jsdom),
-      // NOT overriding to port 5021. Confirm no hardcoded port is present.
       const [parsedUrl] = navigateSpy.mock.calls[0];
       expect(parsedUrl?.path).toEqual(['api', 'auth', 'google-login']);
       expect(parsedUrl?.port).not.toBe(5021);
@@ -306,36 +324,32 @@ describe('AuthService', () => {
 
   describe('licenseTier / isTier1 / isTier2 getters', () => {
     it('JWT with licenseTier="Tier1" → isTier1=true, isTier2=false', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'StoreEmployee', storeId: '1', licenseTier: 'Tier1' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService('error');
+      service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'StoreEmployee', storeId: '1', licenseTier: 'Tier1' }));
       expect(service.isTier1).toBe(true);
       expect(service.isTier2).toBe(false);
       expect(service.licenseTier).toBe('Tier1');
     });
 
     it('JWT with licenseTier="Tier2" → isTier1=true, isTier2=true', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'StoreEmployee', storeId: '1', licenseTier: 'Tier2' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService('error');
+      service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'StoreEmployee', storeId: '1', licenseTier: 'Tier2' }));
       expect(service.isTier1).toBe(true);
       expect(service.isTier2).toBe(true);
       expect(service.licenseTier).toBe('Tier2');
     });
 
     it('JWT with no licenseTier → isTier1=false, isTier2=false, licenseTier==="Free"', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'StoreEmployee', storeId: '1' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService('error');
+      service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'StoreEmployee', storeId: '1' }));
       expect(service.isTier1).toBe(false);
       expect(service.isTier2).toBe(false);
       expect(service.licenseTier).toBe('Free');
     });
 
     it('Admin role → isTier1=true, isTier2=true regardless of licenseTier claim', () => {
-      const token = makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'Administrator' });
-      localStorage.setItem('auth_token', token);
-      const service = createService();
+      const service = createService('error');
+      service.storeToken(makeJwt({ sub: '1', email: 'a@b.com', name: 'A', role: 'Administrator' }));
       expect(service.isTier1).toBe(true);
       expect(service.isTier2).toBe(true);
       expect(service.licenseTier).toBe('Tier2');

--- a/tournament-client/src/app/core/services/auth.service.ts
+++ b/tournament-client/src/app/core/services/auth.service.ts
@@ -10,33 +10,34 @@ export class AuthService {
   private userSubject = new BehaviorSubject<CurrentUser | null>(null);
   currentUser$ = this.userSubject.asObservable();
 
+  private token: string | null = null; // in-memory only — never written to localStorage
+
   constructor(private http: HttpClient) {
-    this.loadFromStorage();
+    this.silentRefresh();
   }
 
-  private loadFromStorage(): void {
-    const token = localStorage.getItem('auth_token');
-    if (token) {
-      try {
-        const payload = JSON.parse(atob(token.split('.')[1]));
-        if (payload.exp && payload.exp * 1000 < Date.now()) {
-          localStorage.removeItem('auth_token');
-          return;
-        }
-        this.userSubject.next(this.decodeJwt(token));
-      } catch {
-        localStorage.removeItem('auth_token');
-      }
-    }
+  private silentRefresh(): void {
+    this.http.post<{ token: string }>(
+      `${environment.apiBase}/api/auth/refresh`,
+      {},
+      { withCredentials: true }
+    ).subscribe({
+      next: res => { this.setToken(res.token); },
+      error: () => {} // no active session — remain unauthenticated
+    });
   }
 
-  storeToken(token: string): void {
-    localStorage.setItem('auth_token', token);
+  private setToken(token: string): void {
+    this.token = token;
     this.userSubject.next(this.decodeJwt(token));
   }
 
+  storeToken(token: string): void {
+    this.setToken(token);
+  }
+
   logout(): void {
-    localStorage.removeItem('auth_token');
+    this.token = null;
     this.userSubject.next(null);
   }
 
@@ -48,21 +49,20 @@ export class AuthService {
   }
 
   getToken(): string | null {
-    const token = localStorage.getItem('auth_token');
-    if (!token) return null;
+    if (!this.token) return null;
     try {
-      const payload = JSON.parse(atob(token.split('.')[1]));
+      const payload = JSON.parse(atob(this.token.split('.')[1]));
       if (payload.exp && payload.exp * 1000 < Date.now()) {
-        localStorage.removeItem('auth_token');
+        this.token = null;
         this.userSubject.next(null);
         return null;
       }
     } catch {
-      localStorage.removeItem('auth_token');
+      this.token = null;
       this.userSubject.next(null);
       return null;
     }
-    return token;
+    return this.token;
   }
 
   /** Calls POST /api/auth/refresh (sends HttpOnly cookie), stores the returned JWT, returns it. */
@@ -96,7 +96,7 @@ export class AuthService {
   }
 
   get licenseTier(): LicenseTier {
-    if (this.isAdmin) return 'Tier2';  // admins always have full access
+    if (this.isAdmin) return 'Tier2'; // admins always have full access
     return this.currentUser?.licenseTier ?? 'Free';
   }
 

--- a/tournament-client/src/app/features/auth/oauth-callback.component.spec.ts
+++ b/tournament-client/src/app/features/auth/oauth-callback.component.spec.ts
@@ -1,55 +1,21 @@
 import { TestBed } from '@angular/core/testing';
-import { ActivatedRoute, convertToParamMap } from '@angular/router';
+import { ActivatedRoute, Router, convertToParamMap, provideRouter } from '@angular/router';
 import { OAuthCallbackComponent } from './oauth-callback.component';
 import { AuthService } from '../../core/services/auth.service';
 
-// ─── window.location.href mock ───────────────────────────────────────────────
-// JSDOM's window.location.href is a configurable:false own accessor — it cannot
-// be redefined or spied on via jest.spyOn or Object.defineProperty.
-//
-// The generated Location wrapper delegates to an internal LocationImpl instance
-// stored at Symbol('impl') on the location object. We access that instance and
-// spy on its _locationObjectSetterNavigate method, which is called (with the
-// parsed URL object) every time location.href is set. Spying on the *instance*
-// (not a prototype) is immune to Jest's per-file module isolation.
-//
-// Note: we do NOT set window.location.hash in tests because JSDOM's hash setter
-// also routes through _locationObjectSetterNavigate, which our spy intercepts
-// before the actual URL update is applied. Instead, we spy on the component's
-// protected readLocationHash() method.
+// ─── Helpers ─────────────────────────────────────────────────────────────────
 
-function getLocationImpl(): any {
-  const implSym = Object.getOwnPropertySymbols(window.location)
-    .find(s => s.toString() === 'Symbol(impl)');
-  return implSym ? (window.location as any)[implSym] : null;
-}
-
-/** Returns true when the parsed JSDOM URL object represents the path '/'. */
-function isRootPath(parsedUrl: { path?: string[] }): boolean {
-  // '/' parses to { path: [''] } (single empty-string segment)
-  return Array.isArray(parsedUrl?.path) &&
-    parsedUrl.path.length === 1 &&
-    parsedUrl.path[0] === '';
-}
-
-let navigateSpy: jest.SpyInstance;
 let replaceStateSpy: jest.SpyInstance;
+let routerNavigateSpy: jest.SpyInstance;
 
 beforeEach(() => {
-  const impl = getLocationImpl();
-  navigateSpy = jest
-    .spyOn(impl, '_locationObjectSetterNavigate')
-    .mockImplementation(() => {}); // suppress JSDOM "not implemented: navigation" noise
-
   replaceStateSpy = jest.spyOn(history, 'replaceState').mockImplementation(() => {});
 });
 
 afterEach(() => {
-  navigateSpy.mockRestore();
   replaceStateSpy.mockRestore();
+  routerNavigateSpy?.mockRestore();
 });
-
-// ─── Helpers ─────────────────────────────────────────────────────────────────
 
 function makeRoute(params: Record<string, string>) {
   return {
@@ -74,11 +40,14 @@ describe('OAuthCallbackComponent', () => {
     TestBed.configureTestingModule({
       imports: [OAuthCallbackComponent],
       providers: [
+        provideRouter([]),
         { provide: ActivatedRoute, useValue: makeRoute(queryParams) },
         { provide: AuthService, useValue: mockAuthService },
       ],
     });
-    return TestBed.createComponent(OAuthCallbackComponent);
+    const fixture = TestBed.createComponent(OAuthCallbackComponent);
+    routerNavigateSpy = jest.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+    return fixture;
   }
 
   /** Creates and initialises the component with an optional hash fragment. */
@@ -118,9 +87,8 @@ describe('OAuthCallbackComponent', () => {
 
   it('redirects to "/" after storing the hash token', () => {
     setup({}, '#token=my-jwt-token');
-    expect(navigateSpy).toHaveBeenCalledTimes(1);
-    const [parsedUrl] = navigateSpy.mock.calls[0];
-    expect(isRootPath(parsedUrl)).toBe(true);
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/']);
   });
 
   it('stores the token before redirecting', () => {
@@ -130,7 +98,7 @@ describe('OAuthCallbackComponent', () => {
 
     const order: string[] = [];
     mockAuthService.storeToken.mockImplementation(() => order.push('storeToken'));
-    navigateSpy.mockImplementation(() => order.push('redirect'));
+    routerNavigateSpy.mockImplementation(() => { order.push('redirect'); return Promise.resolve(true); });
 
     fixture.detectChanges(); // triggers ngOnInit
 
@@ -146,16 +114,14 @@ describe('OAuthCallbackComponent', () => {
 
   it('redirects to "/" when there is no hash token', () => {
     setup({ error: 'access_denied' });
-    expect(navigateSpy).toHaveBeenCalledTimes(1);
-    const [parsedUrl] = navigateSpy.mock.calls[0];
-    expect(isRootPath(parsedUrl)).toBe(true);
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/']);
   });
 
   it('redirects to "/" when both hash token and error are absent', () => {
     setup({});
-    expect(navigateSpy).toHaveBeenCalledTimes(1);
-    const [parsedUrl] = navigateSpy.mock.calls[0];
-    expect(isRootPath(parsedUrl)).toBe(true);
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/']);
     expect(mockAuthService.storeToken).not.toHaveBeenCalled();
   });
 
@@ -178,26 +144,22 @@ describe('OAuthCallbackComponent', () => {
   it('redirects to a valid relative returnUrl from sessionStorage', () => {
     sessionStorage.setItem('auth_return_url', '/events/42');
     setup({}, '#token=my-jwt');
-    expect(navigateSpy).toHaveBeenCalledTimes(1);
-    const [parsedUrl] = navigateSpy.mock.calls[0];
-    // /events/42 should parse to a path with segments ['events', '42']
-    expect(parsedUrl?.path).toEqual(['events', '42']);
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/events/42']);
   });
 
   it('falls back to "/" when returnUrl is an absolute external URL', () => {
     sessionStorage.setItem('auth_return_url', 'https://evil.com/steal');
     setup({}, '#token=my-jwt');
-    expect(navigateSpy).toHaveBeenCalledTimes(1);
-    const [parsedUrl] = navigateSpy.mock.calls[0];
-    expect(isRootPath(parsedUrl)).toBe(true);
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/']);
   });
 
   it('falls back to "/" when returnUrl starts with //', () => {
     sessionStorage.setItem('auth_return_url', '//evil.com/steal');
     setup({}, '#token=my-jwt');
-    expect(navigateSpy).toHaveBeenCalledTimes(1);
-    const [parsedUrl] = navigateSpy.mock.calls[0];
-    expect(isRootPath(parsedUrl)).toBe(true);
+    expect(routerNavigateSpy).toHaveBeenCalledTimes(1);
+    expect(routerNavigateSpy).toHaveBeenCalledWith(['/']);
   });
 
   it('removes returnUrl from sessionStorage after redirect', () => {

--- a/tournament-client/src/app/features/auth/oauth-callback.component.ts
+++ b/tournament-client/src/app/features/auth/oauth-callback.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, OnInit } from '@angular/core';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { AuthService } from '../../core/services/auth.service';
 
 @Component({
@@ -12,6 +12,7 @@ import { AuthService } from '../../core/services/auth.service';
 export class OAuthCallbackComponent implements OnInit {
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private authService: AuthService
   ) {}
 
@@ -31,22 +32,21 @@ export class OAuthCallbackComponent implements OnInit {
 
     if (token) {
       this.authService.storeToken(token);
-      // Full page reload so AuthService.loadFromStorage() runs fresh
-      // and the toolbar renders with the correct user state from the start.
+      // Token is now in-memory — no page reload needed.
+      // Navigate to the return URL (or root) using the Angular Router.
       const returnUrl = sessionStorage.getItem('auth_return_url') ?? '/';
       sessionStorage.removeItem('auth_return_url');
       const safeUrl = returnUrl.startsWith('/') && !returnUrl.startsWith('//')
         ? returnUrl
         : '/';
-      window.location.href = safeUrl;
+      this.router.navigate([safeUrl]);
     } else {
       console.error('OAuth callback error:', error);
-      window.location.href = '/';
+      this.router.navigate(['/']);
     }
   }
 
-  // Extracted for testability: JSDOM's location setter spy intercepts hash
-  // assignments before they take effect, so tests spy on this method instead.
+  // Extracted for testability: allows tests to supply a mock hash value.
   protected readLocationHash(): string {
     return window.location.hash;
   }


### PR DESCRIPTION
## Summary
- JWT access token is now stored exclusively in-memory (private `token` field on `AuthService`) — never written to `localStorage` or `sessionStorage`
- On page load, `AuthService` constructor silently calls `POST /api/auth/refresh` with the existing HttpOnly refresh cookie to restore the session
- `OAuthCallbackComponent` now uses `Router.navigate()` instead of `window.location.href`, eliminating the need for a full page reload after OAuth login

## Test plan
- [x] `auth.service.spec.ts` fully rewritten with `HttpClientTestingModule` — covers silent refresh success/failure, storeToken, logout, getToken expiry, all role/tier getters (53 tests pass)
- [x] `oauth-callback.component.spec.ts` updated — window impl spy replaced with Router.navigate spy (all existing test descriptions preserved)
- [x] `dotnet build` — 0 errors
- [x] `ng build` — 0 errors
- [x] `grep auth_token *.ts` — no localStorage references in implementation files

References #89

🤖 Generated with [Claude Code](https://claude.com/claude-code) · Model: `claude-sonnet-4-6`